### PR TITLE
remove sorted list structure in the RDF code

### DIFF
--- a/geotimeversion.ttl
+++ b/geotimeversion.ttl
@@ -1,5 +1,5 @@
+# removed sorted list structures in many places 
 # namespace definitions
-
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
@@ -850,17 +850,15 @@ isc:FormationOfEarthTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "4600"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [
     time:nominalPosition "Not defined"^^xsd:string ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -879,12 +877,10 @@ isc:BaseArcheanTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "4000"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -903,12 +899,10 @@ isc:BasePaleoarcheanTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "3600"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -927,12 +921,10 @@ isc:BaseMesoarcheanTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "3200"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -951,12 +943,10 @@ isc:BaseNeoarcheanTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "2800"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -977,12 +967,10 @@ isc:BaseProterozoicTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "2500"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -1001,12 +989,10 @@ isc:BaseRhyacianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "2300"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -1025,12 +1011,10 @@ isc:BaseOrosirianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "2050"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -1049,12 +1033,10 @@ isc:BaseStatherianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "1800"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
 .
 
 
@@ -1074,12 +1056,10 @@ isc:BaseMesoproterozoicTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "1600"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
 .
 
 
@@ -1098,12 +1078,10 @@ isc:BaseEctasianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "1400"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
 .
 
 
@@ -1122,12 +1100,10 @@ isc:BaseStenianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "1200"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
 .
 
 
@@ -1147,34 +1123,30 @@ isc:BaseNeoproterozoicTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "1000"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
 .
 
 
 # crogenian numericera and GeochronologicBoundary structure
 isc:BaseCryogenian
   dc:description
-  (
     [
     rdf:type gts:GeochronologicBoundary ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04
-    ]
+    ],
 
     [
     rdf:type gts:NumericEraBoundary ;
     skos:inScheme ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
-    ]
+    ],
 
     [
     gts:stratotype isc:BaseCryogenianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdf:type thors:EraBoundary ;
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
@@ -1187,17 +1159,15 @@ isc:BaseCryogenianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "720"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01
-    ]
+    ],
 
     [
     time:numericPosition "850"^^xsd:decimal ;
     skos:inScheme ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ; 
+    ] ; 
 .
 isc:BaseCryogenianSP
   rdf:type gts:StratigraphicPoint ;
@@ -1213,12 +1183,10 @@ isc:BaseEdiacaran
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseEdiacaranSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Ediacaran"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
   skos:prefLabel "Base of Ediacaran"@en ;
@@ -1228,22 +1196,20 @@ isc:BaseEdiacaranTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "635"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [
     time:numericPosition "630"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12
-    ]
+    ],
 
     [
     time:numericPosition "600"^^xsd:decimal ;
     skos:inScheme ts:isc2004-04
-    ]
-  ) ; 
+    ] ; 
 .
 isc:BaseEdiacaranSP
   rdf:type gts:StratigraphicPoint ;
@@ -1274,12 +1240,10 @@ isc:BasePhanerozoic
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BasePhanerozoicSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Phanerozoic"@en ;
   skos:altLabel "Base of Cambrian"@en ;
   skos:altLabel "Base of Fortunian"@en ;
@@ -1297,28 +1261,24 @@ isc:BasePhanerozoicTime
   gts:positionalUncertainty isc:BasePhanerozoicUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "541"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08
-    ]
+    ],
 
     [
     time:numericPosition "542"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ; 
+    ] ; 
 .
 isc:BasePhanerozoicUncertainty
   rdf:type time:Duration ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
   dc:description
-  (
     [
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
 .
 isc:BasePhanerozoicSP
   rdf:type gts:StratigraphicPoint ;
@@ -1347,12 +1307,10 @@ isc:BaseCambrianStage2
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCambrianStage2SP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Cambrian Stage 2"@en ;
   skos:prefLabel "Base of Cambrian Stage 2"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12 ;
@@ -1362,27 +1320,25 @@ isc:BaseCambrianStage2Time
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "529"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08
-    ]
+    ],
 
     [
     time:numericPosition "528"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [
     time:numericPosition "534.6"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04
-    ]
+    ],
 
     [
     time:nominalPosition "unspecified"^^xsd:string ;
     skos:inScheme ts:isc2005-12
-    ]
-  ) ; 
+    ] ; 
 .
 isc:BaseCambrianStage2SP
   rdf:type gts:StratigraphicPoint ;
@@ -1398,12 +1354,10 @@ isc:BaseCambrianSeries2
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCambrianSeries2SP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Cambrian Series 2"@en ;
   skos:altLabel "Base of Cambrian Stage 3"@en ;
   skos:prefLabel "Base of Cambrian Series 2"@en ;
@@ -1414,16 +1368,14 @@ isc:BaseCambrianSeries2Time
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "521"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04 
-    ]
+    ],
 
     [time:nominalPosition "unspecified"^^xsd:string ;
     skos:inScheme ts:isc2005-12
-    ] 
-  ) ;
+    ] ;
 .
 isc:BaseCambrianSeries2SP
   rdf:type gts:StratigraphicPoint ;
@@ -1439,12 +1391,10 @@ isc:BaseCambrianStage4
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCambrianStage4SP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12  
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Cambrian Stage 4"@en ;
   skos:prefLabel "Base of Cambrian Stage 4"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12 ;  
@@ -1454,27 +1404,25 @@ isc:BaseCambrianStage4Time
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "514"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "515"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [
     time:numericPosition "517"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04
-    ]
+    ],
 
     [
     time:nominalPosition "unspecified"^^xsd:string ;
     skos:inScheme ts:isc2005-12
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseCambrianStage4SP
   rdf:type gts:StratigraphicPoint ;
@@ -1491,17 +1439,15 @@ isc:BaseMiaolingian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:ratifiedGSSP "true"^^xsd:boolean ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07
-    ]
+    ],
 
     [
     gts:stratotype isc:BaseMiaolingianSP ;
     skos:inScheme ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Miaolingian"@en ;
   skos:altlabel "Base of Cambrian Series 3"@en ;
   skos:altlabel "Base of Wuliuan"@en ;
@@ -1514,22 +1460,20 @@ isc:BaseMiaolingianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "509"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "510"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04
-    ]
+    ],
 
     [
     time:nominalPosition "unspecified"^^xsd:string ;
     skos:inScheme ts:isc2005-12
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMiaolingianSP
   rdf:type gts:StratigraphicPoint ;
@@ -1547,12 +1491,10 @@ isc:BaseDrumian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseDrumianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Drumian"@en ;
   rdfs:label "Base of Cambrian Stage 6"@en ;
   skos:prefLabel "Base of Drumian"@en ;
@@ -1563,22 +1505,20 @@ isc:BaseDrumianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "504.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "506.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04
-    ]
+    ],
 
     [
     time:nominalPosition "unspecified"^^xsd:string ;
     skos:inScheme ts:isc2005-12
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseDrumianSP
   rdf:type gts:StratigraphicPoint ;
@@ -1608,12 +1548,10 @@ isc:BaseGuzhangian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseGuzhangianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Guzhangian"@en ;
   rdfs:label "Base of Cambrian Stage 7"@en ;
   skos:prefLabel "Base of Guzhangian"@en ;
@@ -1624,22 +1562,20 @@ isc:BaseGuzhangianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "500.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "503"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04
-    ]
+    ],
 
     [
     time:nominalPosition "unspecified"^^xsd:string ;
     skos:inScheme ts:isc2005-12
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseGuzhangianSP
   rdf:type gts:StratigraphicPoint ;
@@ -1668,12 +1604,10 @@ isc:BaseFurongian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseFurongianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Furongian"@en ;
   skos:altLabel "Base of Paibian"@en ;
   skos:prefLabel "Base of Furongian"@en ;
@@ -1684,37 +1618,33 @@ isc:BaseFurongianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "497"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "499"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "501.0"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]  
+    ],
 
     [
     gts:positionalUncertainty isc:BaseFurongianUncertainty ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
 .
 isc:BaseFurongianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [
     time:numericDuration "2.0"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseFurongianSP
@@ -1745,12 +1675,10 @@ isc:BaseJiangshanian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseJiangshanianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 ;
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Jiangshanian"@en ;
   rdfs:label "Base of Cambrian Stage 9"@en ;  
   skos:prefLabel "Base of Jiangshanian"@en ;
@@ -1761,22 +1689,20 @@ isc:BaseJiangshanianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "494"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "496"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04
-    ]
+    ],
 
     [
     time:nominalPosition "unspecified"^^xsd:string ;
     skos:inScheme ts:isc2005-12
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseJiangshanianSP
   rdf:type gts:StratigraphicPoint ;
@@ -1805,12 +1731,10 @@ isc:BaseCambrianStage10
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCambrianStage10SP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Cambrian Stage 10"@en ;
   skos:prefLabel "Base of Cambrian Stage 10"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12 ;
@@ -1820,22 +1744,20 @@ isc:BaseCambrianStage10Time
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "489.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "492"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04
-    ]
+    ],
 
     [
     time:nominalPosition "unspecified"^^xsd:string ;
     skos:inScheme ts:isc2005-12
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseCambrianStage10SP
   rdf:type gts:StratigraphicPoint ;
@@ -1852,12 +1774,10 @@ isc:BaseOrdovician
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseOrdovicianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Ordovician"@en ;
   skos:altLabel "Base of Lower Ordovician"@en ;
   skos:altLabel "Base of Tremadocian"@en ;
@@ -1870,32 +1790,28 @@ isc:BaseOrdovicianTime
   gts:positionalUncertainty isc:BaseOrdovicianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "485.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "488.3"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
 .
 isc:BaseOrdovicianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseOrdovicianSP
@@ -1925,12 +1841,10 @@ isc:BaseFloian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseFloianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   gts:stratotype isc:BaseFloianSP ;
   rdfs:label "Base of Floian"@en ;
   rdfs:label "Base of Ordovician Stage 2"@en ;
@@ -1943,32 +1857,28 @@ isc:BaseFloianTime
   gts:positionalUncertainty isc:BaseFloianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "477.7"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "478.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
 .
 isc:BaseFloianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseFloianSP
@@ -1999,12 +1909,10 @@ isc:BaseMiddleOrdovician
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseMiddleOrdovicianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Middle Ordovician"@en ;
   skos:altLabel "Base of Dapingian"@en ;
   skos:altLabel "Base of Ordovician Stage 3"@en ;
@@ -2017,33 +1925,29 @@ isc:BaseMiddleOrdovicianTime
   gts:positionalUncertainty isc:BaseMiddleOrdovicianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "470.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "471.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMiddleOrdovicianUncertainty
   rdf:type time:Duration ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
   dc:description
-  (
     [ 
     time:numericDuration "1.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMiddleOrdovicianSP
   rdf:type gts:StratigraphicPoint ;
@@ -2074,12 +1978,10 @@ isc:BaseDarriwilian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseDarriwilianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04  
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Darriwillian"@en ;
   skos:prefLabel "Base of Darriwilian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;  
@@ -2090,32 +1992,28 @@ isc:BaseDarriwilianTime
   gts:positionalUncertainty isc:BaseDarriwilianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "467.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "468.1"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseDarriwilianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseDarriwilianSP
@@ -2146,12 +2044,10 @@ isc:BaseUpperOrdovician
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseUpperOrdovicianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Upper Ordovician"@en ;
   skos:altLabel "Base of Sandbian"@en ;
   skos:altLabel "Base of Ordovician Stage 5"@en ;
@@ -2164,32 +2060,28 @@ isc:BaseUpperOrdovicianTime
   gts:positionalUncertainty isc:BaseUpperOrdovicianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "458.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "460.9"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseUpperOrdovicianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseUpperOrdovicianSP
@@ -2219,12 +2111,10 @@ isc:BaseKatian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseKatianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Katian"@en ;
   rdfs:label "Base of Ordovician Stage 6"@en ;
   skos:prefLabel "Base of Katian"@en ;
@@ -2236,32 +2126,28 @@ isc:BaseKatianTime
   gts:positionalUncertainty isc:BaseKatianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "453.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "455.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseKatianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseKatianSP
@@ -2292,12 +2178,10 @@ isc:BaseHirnantian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseHirnantianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]   
-  ) ;
+    ] ;
   rdfs:label "Base of Hirnantian"@en ;
   skos:prefLabel "Base of Hirnantian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
@@ -2308,37 +2192,33 @@ isc:BaseHirnantianTime
   gts:positionalUncertainty isc:BaseHirnantianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "445.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "445.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
 .
 isc:BaseHirnantianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-    ]
+    ],
 
     [ 
     time:numericDuration "1.6"^^xsd:decimal ;
     skos:inScheme ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseHirnantianSP
@@ -2369,12 +2249,10 @@ isc:BaseSilurian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseSilurianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Silurian"@en ;
   skos:altLabel "Base of Llandovery"@en ;
   skos:altLabel "Base of Rhuddanian"@en ;
@@ -2387,27 +2265,23 @@ isc:BaseSilurianTime
   gts:positionalUncertainty isc:BaseSilurianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "443.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "443.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseSilurianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseSilurianSP
@@ -2438,12 +2312,10 @@ isc:BaseAeronian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseAeronianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Aeronian"@en ;
   skos:prefLabel "Base of Aeronian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
@@ -2454,32 +2326,28 @@ isc:BaseAeronianTime
   gts:positionalUncertainty isc:BaseAeronianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "440.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "439.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseAeronianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseAeronianSP
@@ -2511,12 +2379,10 @@ isc:BaseTelychian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseTelychianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Telychian"@en ;
   skos:prefLabel "Base of Telychian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
@@ -2527,32 +2393,28 @@ isc:BaseTelychianTime
   gts:positionalUncertainty isc:BaseTelychianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "438.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "436.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseTelychianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.9"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseTelychianSP
@@ -2584,12 +2446,10 @@ isc:BaseWenlock
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseWenlockSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Wenlock"@en ;
   skos:altLabel "Base of Sheinwoodian"@en ;
   skos:prefLabel "Base of Wenlock"@en ;
@@ -2601,32 +2461,28 @@ isc:BaseWenlockTime
   gts:positionalUncertainty isc:BaseWenlockUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "433.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "428.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseWenlockUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.3"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseWenlockSP
@@ -2658,12 +2514,10 @@ isc:BaseHomerian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseHomerianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Homerian"@en ;
   skos:prefLabel "Base of Homerian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
@@ -2674,32 +2528,28 @@ isc:BaseHomerianTime
   gts:positionalUncertainty isc:BaseHomerianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "430.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "426.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseHomerianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.4"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseHomerianSP
@@ -2732,12 +2582,10 @@ isc:BaseLudlow
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseLudlowSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Ludlow"@en ;
   skos:altLabel "Base of Gorstian"@en ;
   skos:prefLabel "Base of Ludlow"@en ;
@@ -2749,32 +2597,28 @@ isc:BaseLudlowTime
   gts:positionalUncertainty isc:BaseLudlowUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "427.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "422.9"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseLudlowUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseLudlowSP
@@ -2806,12 +2650,10 @@ isc:BaseLudfordian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseLudfordianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Ludfordian Stage"@en ;
   skos:prefLabel "Base of Ludfordian Stage"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
@@ -2822,32 +2664,28 @@ isc:BaseLudfordianTime
   gts:positionalUncertainty isc:BaseLudfordianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "425.6"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "421.3"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseLudfordianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseLudfordianSP
@@ -2880,12 +2718,10 @@ isc:BasePridoli
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BasePridoliSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Pridoli"@en ;
   skos:prefLabel "Base of Pridoli"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
@@ -2896,32 +2732,28 @@ isc:BasePridoliTime
   gts:positionalUncertainty isc:BasePridoliUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "423.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "418.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BasePridoliUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "2.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BasePridoliSP
@@ -2952,12 +2784,10 @@ isc:BaseDevonian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseDevonianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Devonian"@en ;
   skos:altLabel "Base of Lochkovian"@en ;
   skos:altLabel "Base of Lower Devonian"@en ;
@@ -2970,32 +2800,28 @@ isc:BaseDevonianTime
   gts:positionalUncertainty isc:BaseDevonianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "419.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "416.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseDevonianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "3.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseDevonianSP
@@ -3024,12 +2850,10 @@ isc:BasePragian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BasePragianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Pragian"@en ;
   skos:prefLabel "Base of Pragian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
@@ -3040,32 +2864,28 @@ isc:BasePragianTime
   gts:positionalUncertainty isc:BasePragianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "410.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "411.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BasePragianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "2.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BasePragianSP
@@ -3095,12 +2915,10 @@ isc:BaseEmsian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseEmsianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Emsian"@en ;
   skos:prefLabel "Base of Emsian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
@@ -3111,32 +2929,28 @@ isc:BaseEmsianTime
   gts:positionalUncertainty isc:BaseEmsianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "407.6"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "407.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseEmsianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "2.6"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseEmsianSP
@@ -3167,12 +2981,10 @@ isc:BaseMiddleDevonian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseMiddleDevonianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Middle Devonian"@en ;
   skos:altLabel "Base of Eifelian"@en ;
   skos:prefLabel "Base of Middle Devonian"@en ;
@@ -3184,32 +2996,28 @@ isc:BaseMiddleDevonianTime
   gts:positionalUncertainty isc:BaseMiddleDevonianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "393.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "397.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMiddleDevonianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseMiddleDevonianSP
@@ -3239,12 +3047,10 @@ isc:BaseGivetian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseGivetianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Givetian"@en ;
   skos:prefLabel "Base of Givetian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -3255,32 +3061,28 @@ isc:BaseGivetianTime
   gts:positionalUncertainty isc:BaseGivetianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "387.7"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "391.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseGivetianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseGivetianSP
@@ -3311,12 +3113,10 @@ isc:BaseUpperDevonian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseUpperDevonianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Upper Devonian"@en ;
   skos:altLabel "Base of Frasnian"@en ;
   skos:prefLabel "Base of Upper Devonian"@en ;
@@ -3328,32 +3128,28 @@ isc:BaseUpperDevonianTime
   gts:positionalUncertainty isc:BaseUpperDevonianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "382.7"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "385.3"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseUpperDevonianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.6"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseUpperDevonianSP
@@ -3383,12 +3179,10 @@ isc:BaseFamennian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseFamennianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Famennian"@en ;
   skos:prefLabel "Base of Famennian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -3399,32 +3193,28 @@ isc:BaseFamennianTime
   gts:positionalUncertainty isc:BaseFamennianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "372.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "374.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseFamennianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.6"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseFamennianSP
@@ -3455,12 +3245,10 @@ isc:BaseCarboniferous
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCarboniferousSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Carboniferous"@en ;
   skos:altLabel "Base of Lower Mississippian"@en ;
   skos:altLabel "Base of Mississippian"@en ;
@@ -3474,32 +3262,28 @@ isc:BaseCarboniferousTime
   gts:positionalUncertainty isc:BaseCarboniferousUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "358.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "359.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseCarboniferousUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseCarboniferousSP
@@ -3530,12 +3314,10 @@ isc:BaseMiddleMississippian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseMiddleMississippianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-    ]  
-  ) ;
+    ] ;
   rdfs:label "Base of Middle Mississippian"@en ;
   rdfs:label "Base of Visean"@en ;
   owl:sameAs isc:BaseMiddleMississippian ;
@@ -3549,32 +3331,28 @@ isc:BaseMiddleMississippianTime
   gts:positionalUncertainty isc:BaseMiddleMississippianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "346.7"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "345.3"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMiddleMississippianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.1"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseMiddleMississippianSP
@@ -3604,12 +3382,10 @@ isc:BaseUpperMississippian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseUpperMississippianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Upper Mississippian"@en ;
   skos:altLabel "Base of Serpukhovian"@en ;
   skos:prefLabel "Base of Upper Mississippian"@en ;
@@ -3621,42 +3397,38 @@ isc:BaseUpperMississippianTime
   gts:positionalUncertainty isc:BaseUpperMississippianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "330.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "328.3"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "326.4"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseUpperMississippianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericDuration "1.6"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseUpperMississippianSP
@@ -3675,12 +3447,10 @@ isc:BasePennsylvanian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BasePennsylvanianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Pennsylvanian"@en ;
   skos:altLabel "Base of Bashkirian"@en ;
   skos:altLabel "Base of Lower Pennsylvanian"@en ;
@@ -3693,32 +3463,28 @@ isc:BasePennsylvanianTime
   gts:positionalUncertainty isc:BasePennsylvanianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "323.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "318.1"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BasePennsylvanianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.3"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BasePennsylvanianSP
@@ -3748,12 +3514,10 @@ isc:BaseMiddlePennsylvanian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseMiddlePennsylvanianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Middle Pennsylvanian"@en ;
   skos:altLabel "Base of Moscovian"@en ;
   skos:prefLabel "Base of Middle Pennsylvanian"@en ;
@@ -3765,32 +3529,28 @@ isc:BaseMiddlePennsylvanianTime
   gts:positionalUncertainty isc:BaseMiddlePennsylvanianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "315.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "311.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMiddlePennsylvanianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.1"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseMiddlePennsylvanianSP
@@ -3808,12 +3568,10 @@ isc:BaseUpperPennsylvanian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseUpperPennsylvanianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Upper Pennsylvanian"@en ;
   skos:altLabel "Base of Kasimovian"@en ;
   skos:prefLabel "Base of Upper Pennsylvanian"@en ;
@@ -3825,42 +3583,38 @@ isc:BaseUpperPennsylvanianTime
   gts:positionalUncertainty isc:BaseUpperPennsylvanianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "307.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "307.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "306.5"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseUpperPennsylvanianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseUpperPennsylvanianSP
@@ -3878,12 +3632,10 @@ isc:BaseGzhelian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseGzhelianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Gzhelian"@en ;
   skos:prefLabel "Base of Gzhelian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -3894,42 +3646,38 @@ isc:BaseGzhelianTime
   gts:positionalUncertainty isc:BaseGzhelianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "303.7"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "303.4"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "303.9"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseGzhelianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.9"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericDuration "0.9"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseGzhelianSP
@@ -3947,12 +3695,10 @@ isc:BasePermian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BasePermianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Permian"@en ;
   skos:altLabel "Base of Asselian"@en ;
   skos:altLabel "Base of Cisuralian"@en ;
@@ -3965,37 +3711,33 @@ isc:BasePermianTime
   gts:positionalUncertainty isc:BasePermianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "298.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "299.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BasePermianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.15"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BasePermianSP
@@ -4025,17 +3767,15 @@ isc:BaseSakmarian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:ratifiedGSSP "true"^^xsd:boolean ;
     skos:inScheme ts:isc2018-08
-    ]  
+    ],  
 
     [
     gts:stratotype isc:BaseSakmarianSP ;
     skos:inScheme ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]  
-  ) ;
+    ] ; 
   rdfs:label "Base of Sakmarian"@en ;
   skos:prefLabel "Base of Sakmarian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -4046,52 +3786,48 @@ isc:BaseSakmarianTime
   gts:positionalUncertainty isc:BaseSakmarianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "293.52"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08
-    ]
+    ],
 
     [ 
     time:numericPosition "295.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericPosition "295.5"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08
-    ]
+    ],
 
     [ 
     time:numericPosition "294.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseSakmarianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.17"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.18"^^xsd:decimal ;
     skos:inScheme ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericDuration "0.4"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseSakmarianSP
@@ -4110,12 +3846,10 @@ isc:BaseArtinskian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseArtinskianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Artinskian"@en ;
   skos:prefLabel "Base of Artinskian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ;
@@ -4126,37 +3860,33 @@ isc:BaseArtinskianTime
   gts:positionalUncertainty isc:BaseArtinskianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "290.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "284.4"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseArtinskianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.26"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericDuration "0.1"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseArtinskianSP
@@ -4175,12 +3905,10 @@ isc:BaseKungurian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseKungurianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Kungurian"@en ;
   skos:prefLabel "Base of Kungurian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -4191,37 +3919,33 @@ isc:BaseKungurianTime
   gts:positionalUncertainty isc:BaseKungurianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "283.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericPosition "279.3"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "275.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseKungurianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.6"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseKungurianSP
@@ -4240,12 +3964,10 @@ isc:BaseGuadalupian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseGuadalupianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Guadalupian"@en ;
   skos:altLabel "Base of Roadian"@en ;
   skos:prefLabel "Base of Guadalupian"@en ;
@@ -4257,42 +3979,38 @@ isc:BaseGuadalupianTime
   gts:positionalUncertainty isc:BaseGuadalupianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "272.95"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02 
-    ]
+    ],
 
     [ 
     time:numericPosition "272.3"^^xsd:decimal ;
     skos:inScheme ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "270.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseGuadalupianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.11"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.5"^^xsd:decimal ;
     skos:inScheme ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseGuadalupianSP
@@ -4320,12 +4038,10 @@ isc:BaseWordian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseWordianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Wordian"@en ;
   skos:prefLabel "Base of Wordian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -4336,32 +4052,28 @@ isc:BaseWordianTime
   gts:positionalUncertainty isc:BaseWordianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "268.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "268.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseWordianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseWordianSP
@@ -4389,12 +4101,10 @@ isc:BaseCapitanian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCapitanianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Capitanian"@en ;
   skos:prefLabel "Base of Capitanian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -4405,32 +4115,28 @@ isc:BaseCapitanianTime
   gts:positionalUncertainty isc:BaseCapitanianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "265.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "265.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseCapitanianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseCapitanianSP
@@ -4458,12 +4164,10 @@ isc:BaseLopingian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseLopingianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   gts:stratotype isc:BaseLopingianSP ;
   rdfs:label "Base of Lopingian"@en ;
   skos:altLabel "Base of Wuchiapingian"@en ;
@@ -4476,47 +4180,43 @@ isc:BaseLopingianTime
   gts:positionalUncertainty isc:BaseLopingianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "259.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02 
-    ]
+    ],
 
     [ 
     time:numericPosition "259.8"^^xsd:decimal ;
     skos:inScheme ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericPosition "259.9"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "260.4"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseLopingianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.4"^^xsd:decimal ;
     skos:inScheme ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseLopingianSP
@@ -4546,12 +4246,10 @@ isc:BaseChanghsingian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseChanghsingianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12 
-    ]  
-  ) ;
+    ] ; 
   rdfs:label "Base of Changhsingian"@en ;
   skos:prefLabel "Base of Changhsingian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -4562,42 +4260,38 @@ isc:BaseChanghsingianTime
   gts:positionalUncertainty isc:BaseChanghsingianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "254.14"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericPosition "254.2"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "253.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseChanghsingianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.07"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.1"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseChanghsingianSP
@@ -4627,12 +4321,10 @@ isc:BaseMesozoic
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseMesozoicSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Mesozoic"@en ;
   skos:altLabel "Base of Induan"@en ;
   skos:altLabel "Base of Lower Triassic"@en ;
@@ -4646,52 +4338,48 @@ isc:BaseMesozoicTime
   gts:positionalUncertainty isc:BaseMesozoicUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "251.902"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02 
-    ]
+    ],
 
     [ 
     time:numericPosition "252.17"^^xsd:decimal ;
     skos:inScheme ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericPosition "252.2"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "251.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMesozoicUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.024"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.06"^^xsd:decimal ;
     skos:inScheme ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericDuration "0.5"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.4"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseMesozoicSP
@@ -4722,12 +4410,10 @@ isc:BaseOlenekian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseOlenekianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Olenekian"@en ;
   skos:prefLabel "Base of Olenekian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -4737,37 +4423,33 @@ isc:BaseOlenekianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "251.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "249.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "249.7"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseOlenekianUncertainty ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseOlenekianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
-   [ 
+    [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseOlenekianSP
@@ -4795,12 +4477,10 @@ isc:BaseMiddleTriassic
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseMiddleTriassicSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Middle Triassic"@en ;
   skos:altLabel "Base of Anisian"@en ;
   skos:prefLabel "Base of Middle Triassic"@en ;
@@ -4811,37 +4491,33 @@ isc:BaseMiddleTriassicTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "247.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "245.9"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "245.0"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseMiddleTriassicUncertainty ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMiddleTriassicUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
-   [ 
+    [ 
     time:numericDuration "1.5"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseMiddleTriassicSP
@@ -4869,12 +4545,10 @@ isc:BaseLadinian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseLadinianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12 
-    ]   
-  ) ;
+    ] ;
   rdfs:label "Base of Ladinian"@en ;
   skos:prefLabel "Base of Ladinian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -4884,32 +4558,28 @@ isc:BaseLadinianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "242"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "237.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseLadinianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseLadinianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
-   [ 
+    [ 
     time:numericDuration "2.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseLadinianSP
@@ -4939,12 +4609,10 @@ isc:BaseUpperTriassic
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseUpperTriassicSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-    ]   
-  ) ;
+    ] ;
   rdfs:label "Base of Upper Triassic"@en ;
   skos:altLabel "Base of Carnian"@en ;
   skos:prefLabel "Base of Upper Triassic"@en ;
@@ -4955,42 +4623,38 @@ isc:BaseUpperTriassicTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "237"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericPosition "235"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "228.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "228"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseUpperTriassicUncertainty ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseUpperTriassicUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
-   [ 
+    [ 
     time:numericDuration "2.0"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseUpperTriassicSP
@@ -5020,12 +4684,10 @@ isc:BaseNorian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseNorianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Norian"@en ;
   skos:prefLabel "Base of Norian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5035,37 +4697,33 @@ isc:BaseNorianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "227"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]
+    ],
 
     [ 
     time:numericPosition "228"^^xsd:decimal ;
     skos:inScheme ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "216.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseNorianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseNorianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
-   [ 
+    [ 
     time:numericDuration "2.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseNorianSP
@@ -5083,12 +4741,10 @@ isc:BaseRhaetian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseRhaetianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Rhaetian"@en ;
   skos:prefLabel "Base of Rhaetian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5098,32 +4754,28 @@ isc:BaseRhaetianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "208.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "203.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseRhaetianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseRhaetianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
-   [ 
+    [ 
     time:numericDuration "1.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ] 
-  ) ;
+    ] ;
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseRhaetianSP
@@ -5141,12 +4793,10 @@ isc:BaseJurassic
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseJurassicSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09 
-    ]   
-  ) ;
+    ] ;
   rdfs:label "Base of Jurassic"@en ;
   skos:altLabel "Base of Hettangian"@en ;
   skos:altLabel "Base of Lower Jurassic"@en ;
@@ -5159,32 +4809,28 @@ isc:BaseJurassicTime
   gts:positionalUncertainty isc:BaseJurassicUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "201.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "199.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseJurassicUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseJurassicSP
@@ -5214,12 +4860,10 @@ isc:BaseSinemurian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseSinemurianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Sinemurian"@en ;
   skos:prefLabel "Base of Sinemurian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5230,32 +4874,28 @@ isc:BaseSinemurianTime
   gts:positionalUncertainty isc:BaseSinemurianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "199.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "196.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseSinemurianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseSinemurianSP
@@ -5285,12 +4925,10 @@ isc:BasePliensbachian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BasePliensbachianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Pliensbachian"@en ;
   skos:prefLabel "Base of Pliensbachian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5301,32 +4939,28 @@ isc:BasePliensbachianTime
   gts:positionalUncertainty isc:BasePliensbachianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "190.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "189.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BasePliensbachianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BasePliensbachianSP
@@ -5357,12 +4991,10 @@ isc:BaseToarcian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseToarcianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01 
-    ]  
-  ) ;
+    ] ; 
   rdfs:label "Base of Toarcian"@en ;
   skos:prefLabel "Base of Toarcian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5373,32 +5005,28 @@ isc:BaseToarcianTime
   gts:positionalUncertainty isc:BaseToarcianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "182.7"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "183.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseToarcianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseToarcianSP
@@ -5417,12 +5045,10 @@ isc:BaseMiddleJurassic
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseMiddleJurassicSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Middle Jurassic"@en ;
   skos:altLabel "Base of Aalenian"@en ;
   skos:prefLabel "Base of Middle Jurassic"@en ;
@@ -5434,32 +5060,28 @@ isc:BaseMiddleJurassicTime
   gts:positionalUncertainty isc:BaseMiddleJurassicUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "174.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "175.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMiddleJurassicUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "2.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseMiddleJurassicSP
@@ -5489,12 +5111,10 @@ isc:BaseBajocian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseBajocianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Bajocian"@en ;
   skos:prefLabel "Base of Bajocian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5505,32 +5125,28 @@ isc:BaseBajocianTime
   gts:positionalUncertainty isc:BaseBajocianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "170.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "171.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseBajocianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "3.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseBajocianSP
@@ -5560,12 +5176,10 @@ isc:BaseBathonian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseBathonianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-    ]   
-  ) ;
+    ] ;
   rdfs:label "Base of Bathonian"@en ;
   skos:prefLabel "Base of Bathonian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5576,32 +5190,28 @@ isc:BaseBathonianTime
   gts:positionalUncertainty isc:BaseBathonianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "168.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "167.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseBathonianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "3.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseBathonianSP
@@ -5631,12 +5241,10 @@ isc:BaseCallovian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCallovianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Callovian"@en ;
   skos:prefLabel "Base of Callovian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5647,32 +5255,28 @@ isc:BaseCallovianTime
   gts:positionalUncertainty isc:BaseCallovianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "166.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "164.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseCallovianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "4.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseCallovianSP
@@ -5691,12 +5295,10 @@ isc:BaseUpperJurassic
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseUpperJurassicSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Upper Jurassic"@en ;
   skos:altLabel "Base of Oxfordian"@en ;
   skos:prefLabel "Base of Upper Jurassic"@en ;
@@ -5708,32 +5310,28 @@ isc:BaseUpperJurassicTime
   gts:positionalUncertainty isc:BaseUpperJurassicUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "163.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "161.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseUpperJurassicUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "4.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseUpperJurassicSP
@@ -5751,12 +5349,10 @@ isc:BaseKimmeridgian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseKimmeridgianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Kimmeridgian"@en ;
   skos:prefLabel "Base of Kimmeridgian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5766,47 +5362,43 @@ isc:BaseKimmeridgianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "157.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "155.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "155.7"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12
-    ]
+    ],
 
     [ 
     time:numericPosition "155.0"^^xsd:decimal ;
     skos:inScheme ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseKimmeridgianUncertainty ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseKimmeridgianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "4.0"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseKimmeridgianSP
@@ -5832,12 +5424,10 @@ isc:BaseTithonian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseTithonianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Tithonian"@en ;
   skos:prefLabel "Base of Tithonian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5848,32 +5438,28 @@ isc:BaseTithonianTime
   gts:positionalUncertainty isc:BaseTithonianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "152.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "150.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseTithonianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.4"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseTithonianSP
@@ -5891,12 +5477,10 @@ isc:BaseCretaceous
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCretaceousSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Cretaceous"@en ;
   skos:altLabel "Base of Berriasian"@en ;
   skos:altLabel "Base of Lower Cretaceous"@en ;
@@ -5908,32 +5492,28 @@ isc:BaseCretaceousTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "145.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "145.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseCretaceousUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseCretaceousUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "4.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseCretaceousSP
@@ -5950,12 +5530,10 @@ isc:BaseValanginian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseValanginianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Valanginian"@en ;
   skos:prefLabel "Base of Valanginian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -5965,37 +5543,33 @@ isc:BaseValanginianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "139.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "140.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseValanginianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseValanginianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "3.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseValanginianSP
   rdf:type gts:StratigraphicPoint ;
-  gts:correlationEvent "Calpionellid FAD Calpionellites darderi (Base of Calpionellid Zone E) ;; followed by ammonite FAD “Thurmanniceras” pertransiens"@en ;
+  gts:correlationEvent "Calpionellid FAD Calpionellites darderi (Base of Calpionellid Zone E) ; followed by ammonite FAD “Thurmanniceras” pertransiens"@en ;
   rdfs:comment "candidates are near Montbrunles- Bains (Drôme province, SE France) ; and Cañada Luenga (Betic Cordillera, S. ainSP) "@en ;
   rdfs:label "Stratotype Point Base of Albian"@en ;
   rdfs:seeAlso <http://www.stratigraphy.org/GSSP/index.html> ;
@@ -6008,12 +5582,10 @@ isc:BaseHauterivian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseHauterivianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Hauterivian"@en ;
   skos:prefLabel "Base of Hauterivian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6023,37 +5595,33 @@ isc:BaseHauterivianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "132.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "133.9"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [ 
     time:numericPosition "136.4"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseHauterivianUncertainty ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseHauterivianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "2.0"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseHauterivianSP
@@ -6071,12 +5639,10 @@ isc:BaseBarremian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseBarremianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Barremian"@en ;
   skos:prefLabel "Base of Barremian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6086,32 +5652,28 @@ isc:BaseBarremianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "129.4"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "130.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseBarremianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseBarremianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseBarremianSP
@@ -6129,12 +5691,10 @@ isc:BaseAptian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseAptianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Aptian"@en ;
   skos:prefLabel "Base of Aptian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6144,27 +5704,23 @@ isc:BaseAptianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "125.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseAptianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseAptianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseAptianSP
@@ -6182,12 +5738,10 @@ isc:BaseAlbian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseAlbianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04
-    ]   
-  ) ;
+    ] ;
   rdfs:label "Base of Albian"@en ;
   skos:prefLabel "Base of Albian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6197,32 +5751,28 @@ isc:BaseAlbianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "113.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "112.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseAlbianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseAlbianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseAlbianSP
@@ -6242,12 +5792,10 @@ isc:BaseUpperCretaceous
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseUpperCretaceousSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Upper Cretaceous"@en ;
   skos:altLabel "Base of Cenomanian"@en ;
   skos:prefLabel "Base of Upper Cretaceous"@en ;
@@ -6258,32 +5806,28 @@ isc:BaseUpperCretaceousTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "100.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "99.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseUpperCretaceousUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseUpperCretaceousUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.9"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseUpperCretaceousSP
@@ -6313,12 +5857,10 @@ isc:BaseTuronian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseTuronianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Turonian"@en ;
   skos:prefLabel "Base of Turonian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6328,37 +5870,33 @@ isc:BaseTuronianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "93.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "93.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "93.5"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseTuronianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseTuronianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseTuronianSP
@@ -6388,12 +5926,10 @@ isc:BaseConiacian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseConiacianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Coniacian"@en ;
   skos:prefLabel "Base of Coniacian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6403,42 +5939,38 @@ isc:BaseConiacianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "89.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "88.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "89.3"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseConiacianUncertainty ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseConiacianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "1.0"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseConiacianSP
@@ -6456,12 +5988,10 @@ isc:BaseSantonian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseSantonianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01
-    ]   
-  ) ;
+    ] ;
   rdfs:label "Base of Santonian"@en ;
   skos:prefLabel "Base of Santonian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6472,32 +6002,28 @@ isc:BaseSantonianTime
   gts:positionalUncertainty isc:BaseSantonianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "86.3"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "85.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseSantonianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.5"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseSantonianSP
@@ -6527,12 +6053,10 @@ isc:BaseCampanian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCampanianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Campanian"@en ;
   skos:prefLabel "Base of Campanian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6543,32 +6067,28 @@ isc:BaseCampanianTime
   gts:positionalUncertainty isc:BaseCampanianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "83.6"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "83.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseCampanianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseCampanianSP
@@ -6586,12 +6106,10 @@ isc:BaseMaastrichtian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseMaastrichtianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Maastrichtian"@en ;
   skos:prefLabel "Base of Maastrichtian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6602,32 +6120,28 @@ isc:BaseMaastrichtianTime
   gts:positionalUncertainty isc:BaseMaastrichtianUncertainty ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "72.1"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "70.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMaastrichtianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericDuration "0.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseMaastrichtianSP
@@ -6657,12 +6171,10 @@ isc:BaseCenozoic
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
   gts:stratotype isc:BaseCenozoicSP ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Cenozoic"@en ;
   skos:altLabel "Base of Danian"@en ;
   skos:altLabel "Base of Paleocene"@en ;
@@ -6675,32 +6187,28 @@ isc:BaseCenozoicTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "66.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "65.5"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseCenozoicUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseCenozoicUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.3"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseCenozoicSP
@@ -6730,12 +6238,10 @@ isc:BaseSelandian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseSelandianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-    ]   
-  ) ;
+    ] ; 
   rdfs:label "Base of Selandian"@en ;
   skos:prefLabel "Base of Selandian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6745,37 +6251,33 @@ isc:BaseSelandianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "61.6"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "61.1"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
+    ],
 
     [ 
     time:numericPosition "61.7"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseSelandianUncertainty ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseSelandianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseSelandianSP
@@ -6805,12 +6307,10 @@ isc:BaseThanetian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseThanetianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]  
-  ) ;
+    ] ; 
   rdfs:label "Base of Thanetian"@en ;
   skos:prefLabel "Base of Thanetian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6820,32 +6320,28 @@ isc:BaseThanetianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "59.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "58.7"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseThanetianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseThanetianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseThanetianSP
@@ -6876,12 +6372,10 @@ isc:BaseEocene
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseEoceneSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Eocene"@en ;
   skos:altLabel "Base of Ypresian"@en ;
   skos:prefLabel "Base of Eocene"@en ;
@@ -6892,32 +6386,28 @@ isc:BaseEoceneTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "56.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "55.8"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseEoceneUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseEoceneUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseEoceneSP
@@ -6948,12 +6438,10 @@ isc:BaseLutetian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
   gts:stratotype isc:BaseLutetianSP ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08
-    ]   
-  ) ;
+    ] ; 
   rdfs:label "Base of Lutetian"@en ;
   skos:prefLabel "Base of Lutetian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -6963,32 +6451,28 @@ isc:BaseLutetianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "47.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "48.6"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseLutetianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseLutetianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseLutetianSP
@@ -7018,12 +6502,10 @@ isc:BaseBartonian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseBartonianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Bartonian"@en ;
   skos:prefLabel "Base of Bartonian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7033,37 +6515,33 @@ isc:BaseBartonianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "41.2"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10 
-    ]
+    ],
 
     [ 
     time:numericPosition "41.3"^^xsd:decimal ;
     skos:inScheme ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "40.4"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseBartonianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseBartonianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseBartonianSP
@@ -7081,12 +6559,10 @@ isc:BasePriabonian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BasePriabonianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Priabonian"@en ;
   skos:prefLabel "Base of Priabonian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7096,37 +6572,33 @@ isc:BasePriabonianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "37.8"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10 
-    ]
+    ],
 
     [ 
     time:numericPosition "38.0"^^xsd:decimal ;
     skos:inScheme ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "37.2"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BasePriabonianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BasePriabonianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.1"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BasePriabonianSP
@@ -7145,12 +6617,10 @@ isc:BaseOligocene
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseOligoceneSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Oligocene"@en ;
   skos:altLabel "Base of Rupelian"@en ;
   skos:prefLabel "Base of Oligocene"@en ;
@@ -7161,27 +6631,23 @@ isc:BaseOligoceneTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "33.9"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseOligoceneUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseOligoceneUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.1"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseOligoceneSP
@@ -7211,12 +6677,10 @@ isc:BaseChattian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseChattianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Chattian"@en ;
   skos:prefLabel "Base of Chattian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7226,37 +6690,33 @@ isc:BaseChattianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "27.82"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02
-    ]
+    ],
 
     [ 
     time:numericPosition "28.1"^^xsd:decimal ;
     skos:inScheme ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "28.4"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
+    ],
 
     [
     gts:positionalUncertainty isc:BaseChattianUncertainty ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseChattianUncertainty
   rdf:type time:Duration ;
   dc:description
-  (
     [ 
     time:numericDuration "0.1"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;  
+    ] ;  
   time:unitType <http://www.opengis.net/def/uom/UCUM/0/Ma> ;
 .
 isc:BaseChattianSP
@@ -7277,12 +6737,10 @@ isc:BaseNeogene
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseNeogeneSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Neogene"@en ;
   skos:altLabel "Base of Aquitanian"@en ;
   skos:altLabel "Base of Miocene"@en ;
@@ -7294,12 +6752,10 @@ isc:BaseNeogeneTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "23.03"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseNeogeneSP
   rdf:type gts:StratigraphicPoint ;
@@ -7328,12 +6784,10 @@ isc:BaseBurdigalian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseBurdigalianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Burdigalian"@en ;
   skos:prefLabel "Base of Burdigalian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7343,17 +6797,15 @@ isc:BaseBurdigalianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "20.44"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "20.43"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseBurdigalianSP
   rdf:type gts:StratigraphicPoint ;
@@ -7370,12 +6822,10 @@ isc:BaseLanghian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseLanghianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Langhian"@en ;
   skos:prefLabel "Base of Langhian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7385,12 +6835,10 @@ isc:BaseLanghianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "15.97"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseLanghianSP
   rdf:type gts:StratigraphicPoint ;
@@ -7407,12 +6855,10 @@ isc:BaseSerravallian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseSerravallianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08 
-    ] 
-  ) ;
+    ] ;
   rdfs:label "Base of Serravallian"@en ;
   skos:prefLabel "Base of Serravallian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7422,17 +6868,15 @@ isc:BaseSerravallianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "13.82"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "13.65"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseSerravallianSP
   rdf:type gts:StratigraphicPoint ;
@@ -7461,12 +6905,10 @@ isc:BaseTortonian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseTortonianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Tortonian"@en ;
   skos:prefLabel "Base of Tortonian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7476,22 +6918,20 @@ isc:BaseTortonianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "11.63"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "11.62"^^xsd:decimal ;
     skos:inScheme ts:isc2014-02, ts:isc2013-01, ts:isc2012-08
-    ]
+    ],
 
     [ 
     time:numericPosition "11.608"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseTortonianSP
   rdf:type gts:StratigraphicPoint ;
@@ -7521,12 +6961,10 @@ isc:BaseMessinian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseMessinianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Messinian"@en ;
   skos:prefLabel "Base of Messinian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7536,12 +6974,10 @@ isc:BaseMessinianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "7.246"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseMessinianSP
   rdf:type gts:StratigraphicPoint ;
@@ -7571,12 +7007,10 @@ isc:BasePliocene
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BasePlioceneSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Pliocene"@en ;
   skos:altLabel "Base of Zanclean"@en ;
   skos:prefLabel "Base of Pliocene"@en ;
@@ -7587,17 +7021,15 @@ isc:BasePlioceneTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "5.333"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "5.332"^^xsd:decimal ;
     skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
 .
 isc:BasePlioceneSP
   rdf:type gts:StratigraphicPoint ;
@@ -7626,12 +7058,10 @@ isc:BasePiacenzian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BasePiacenzianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Piacenzian"@en ;
   skos:prefLabel "Base of Piacenzian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7641,12 +7071,10 @@ isc:BasePiacenzianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "3.600"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
 .
 isc:BasePiacenzianSP
   rdf:type gts:StratigraphicPoint ;
@@ -7675,12 +7103,10 @@ isc:BaseGelasian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseQuaternarySP ;
     skos:inScheme ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Quaternary"@en ;
   skos:altLabel "Base of Gelasian"@en ;
   skos:prefLabel "Base of Quaternary"@en ;
@@ -7691,12 +7117,10 @@ isc:BaseGelasianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "2.588"^^xsd:decimal ;
     skos:inScheme ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -7706,12 +7130,10 @@ isc:BaseQuaternary
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseQuaternarySP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Quaternary"@en ;
   skos:altLabel "Base of Gelasian"@en ;
   skos:altLabel "Base of Pleistocene"@en ;
@@ -7723,12 +7145,10 @@ isc:BaseQuaternaryTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "2.588"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 ;
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseQuaternarySP
   rdf:type gts:StratigraphicPoint ;
@@ -7759,12 +7179,10 @@ isc:BaseCalabrian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:stratotype isc:BaseCalabrianSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-    ]
-  ) ;
+    ] ;
   rdfs:label "Base of Calabrian"@en ;
   skos:prefLabel "Base of Calabrian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 ; 
@@ -7774,17 +7192,15 @@ isc:BaseCalabrianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "1.80"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "1.806"^^xsd:decimal ;
     skos:inScheme  ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseCalabrianSP
   rdf:type gts:StratigraphicPoint ;
@@ -7824,12 +7240,10 @@ isc:BaseMiddlePleistoceneTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "0.781"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -7846,12 +7260,10 @@ isc:BaseUpperPleistoceneTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "0.126"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -7861,12 +7273,10 @@ isc:BaseHolocene
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
   gts:stratotype isc:BaseHoloceneSP ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-    ]  
-  ) ;
+    ] ; 
   rdfs:label "Base of Holocene"@en ;
   skos:prefLabel "Base of Holocene"@en ;
   skos:altLabel "Base of Greenlandian"@en ;
@@ -7877,22 +7287,20 @@ isc:BaseHoloceneTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "0.0117"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-    ]
+    ],
 
     [ 
     time:numericPosition "0.0118"^^xsd:decimal ;
     skos:inScheme ts:isc2006-04, ts:isc2005-12 
-    ]
+    ],
 
     [ 
     time:numericPosition "0.0115"^^xsd:decimal ;
     skos:inScheme ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
 .
 isc:BaseHoloceneSP
   rdf:type gts:StratigraphicPoint ;
@@ -7923,12 +7331,10 @@ isc:BaseNorthgrippian
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:ratifiedGSSP "true"^^xsd:boolean ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07
-    ]  
-  ) ;
+    ] ; 
   rdfs:label "Base of Northgrippian"@en ;
   skos:prefLabel "Base of Northgrippian"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07 ;
@@ -7938,12 +7344,10 @@ isc:BaseNorthgrippianTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "0.0082"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -7953,12 +7357,10 @@ isc:BaseMeghalayan
   rdf:type skos:Concept ;
   rdf:type time:Instant ;
   dc:description
-  (
     [
     gts:ratifiedGSSP "true"^^xsd:boolean ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07
-    ]  
-  ) ;  rdfs:label "Base of Meghalayan"@en ;
+    ] ;   rdfs:label "Base of Meghalayan"@en ;
   skos:prefLabel "Base of Meghalayan"@en ;
   skos:inScheme ts:isc2018-08, ts:isc2018-07 ;
   time:inTemporalPosition isc:BaseMeghalayanTime ;
@@ -7967,12 +7369,10 @@ isc:BaseMeghalayanTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [ 
     time:numericPosition "0.0042"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -7990,12 +7390,10 @@ isc:PresentTime
   rdf:type time:TimePosition ;
   time:hasTRS <http://resource.geosciml.org/classifier/cgi/geologicage/ma> ;
   dc:description
-  (
     [
     time:numericPosition "0.0"^^xsd:decimal ;
     skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04 
-    ]
-  ) ;
+    ] ;
 .
 
 
@@ -8032,7 +7430,6 @@ isc:Precambrian
   skos:prefLabel "先カンブリア時代"@ja ;
   skos:prefLabel "前寒武纪"@zh ;
   dc:description  
-    (
       [   
       skos:narrower isc:Archean ;
       skos:narrower isc:Hadean ;
@@ -8055,7 +7452,7 @@ isc:Precambrian
       skos:narrowerTransitive isc:Stenian ;
       skos:narrowerTransitive isc:Tonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08 
-      ]
+      ],
 
       [   
       skos:narrower isc:Archean ;
@@ -8078,7 +7475,7 @@ isc:Precambrian
       skos:narrowerTransitive isc:Stenian ;
       skos:narrowerTransitive isc:Tonian ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:FormationOfEarth ;
@@ -8092,7 +7489,7 @@ isc:Precambrian
       time:intervalMeets isc:Terreneuvian ;
       time:intervalStartedBy isc:Hadean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:FormationOfEarth ;
@@ -8105,7 +7502,7 @@ isc:Precambrian
       time:intervalMeets isc:Phanerozoic ;
       time:intervalStartedBy isc:Archean ;
       skos:inScheme ts:isc2006-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:FormationOfEarth ;
@@ -8118,7 +7515,7 @@ isc:Precambrian
       time:intervalMeets isc:Phanerozoic ;
       time:intervalStartedBy isc:Archean ;
       skos:inScheme ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:FormationOfEarth ;
@@ -8130,8 +7527,7 @@ isc:Precambrian
       time:intervalMeets isc:Phanerozoic ;
       time:intervalStartedBy isc:Archean ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Precambrian> ;
 .
 
@@ -8169,11 +7565,10 @@ isc:Hadean
   skos:prefLabel "冥王代（非公式の）"@ja ;
   skos:topConceptOf <http://resource.geosciml.org/classifier/ics/ischart/2017> ;
   dc:description  
-    (
       [   
       skos:broader isc:Precambrian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:FormationOfEarth ;
@@ -8183,8 +7578,7 @@ isc:Hadean
       time:intervalMeets isc:Eoarchean ;
       time:intervalStarts isc:Precambrian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Hadean> ;
 .
 
@@ -8225,7 +7619,6 @@ isc:Archean
   skos:prefLabel "始生代"@ja ;
   skos:topConceptOf <http://resource.geosciml.org/classifier/ics/ischart/2017> ;
   dc:description
-    (
       [
       skos:broader isc:Precambrian ;
       skos:narrower isc:Eoarchean ;
@@ -8233,7 +7626,7 @@ isc:Archean
       skos:narrower isc:Neoarchean ;
       skos:narrower isc:Paleoarchean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseArchean ;
@@ -8249,7 +7642,7 @@ isc:Archean
       time:intervalMetBy isc:Hadean ;
       time:intervalStartedBy isc:Eoarchean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:FormationOfEarth ;
@@ -8265,8 +7658,7 @@ isc:Archean
       time:intervalStarts isc:Precambrian ;
       time:intervalStartedBy isc:Eoarchean ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Archean> ;
 .
@@ -8307,12 +7699,11 @@ isc:Eoarchean
   skos:prefLabel "始太古代"@zh ;
   skos:prefLabel "暁始生代"@ja ;
   dc:description
-    (
       [
       skos:broader isc:Archean ;
       skos:broaderTransitive isc:Precambrian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseArchean ;
@@ -8322,7 +7713,7 @@ isc:Eoarchean
       time:intervalMetBy isc:Hadean ;
       time:intervalStarts isc:Archean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:FormationOfEarth ;
@@ -8331,8 +7722,7 @@ isc:Eoarchean
       time:intervalMeets isc:Paleoarchean ;
       time:intervalStarts isc:Archean ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Eoarchean> ;
 .
 
@@ -8372,12 +7762,11 @@ isc:Paleoarchean
   skos:prefLabel "古太古代"@zh ;
   skos:prefLabel "古始生代"@ja ;
   dc:description
-    (
       [
       skos:broader isc:Archean ;
       skos:broaderTransitive isc:Precambrian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePaleoarchean ;
@@ -8387,8 +7776,7 @@ isc:Paleoarchean
       time:intervalMeets isc:Mesoarchean ;
       time:intervalMetBy isc:Eoarchean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Paleoarchean> ;
 .
 
@@ -8428,12 +7816,11 @@ isc:Mesoarchean
   skos:prefLabel "中太古代"@zh ;
   skos:prefLabel "中始生代"@ja ;
   dc:description
-    (
       [
       skos:broader isc:Archean ;
       skos:broaderTransitive isc:Precambrian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMesoarchean ;
@@ -8443,8 +7830,7 @@ isc:Mesoarchean
       time:intervalMeets isc:Neoarchean ;
       time:intervalMetBy isc:Paleoarchean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Mesoarchean> ;
 .
 
@@ -8484,12 +7870,11 @@ isc:Neoarchean
   skos:prefLabel "新太古代"@zh ;
   skos:prefLabel "新始生代"@ja ;
   dc:description
-    (
       [
       skos:broader isc:Archean ;
       skos:broaderTransitive isc:Precambrian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeoarchean ;
@@ -8501,8 +7886,7 @@ isc:Neoarchean
       time:intervalMeets isc:Siderian ;
       time:intervalMetBy isc:Mesoarchean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Neoarchean> ;
 .
 
@@ -8541,7 +7925,6 @@ isc:Proterozoic
   skos:prefLabel "原生代"@ja ;
   skos:topConceptOf <http://resource.geosciml.org/classifier/ics/ischart/2017> ;
   dc:description
-    (
       [
       skos:broader isc:Precambrian ;
       skos:narrower isc:Mesoproterozoic ;
@@ -8558,7 +7941,7 @@ isc:Proterozoic
       skos:narrowerTransitive isc:Stenian ;
       skos:narrowerTransitive isc:Tonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseProterozoic ;
@@ -8576,7 +7959,7 @@ isc:Proterozoic
       time:intervalMetBy isc:Neoarchean ;
       time:intervalStartedBy isc:Paleoproterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseProterozoic ;
@@ -8594,7 +7977,7 @@ isc:Proterozoic
       time:intervalMetBy isc:Neoarchean ;
       time:intervalStartedBy isc:Paleoproterozoic ;
       skos:inScheme ts:isc2006-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseProterozoic ;
@@ -8612,7 +7995,7 @@ isc:Proterozoic
       time:intervalMetBy isc:Neoarchean ;
       time:intervalStartedBy isc:Paleoproterozoic ;
       skos:inScheme ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseProterozoic ;
@@ -8629,8 +8012,7 @@ isc:Proterozoic
       time:intervalMetBy isc:Neoarchean ;
       time:intervalStartedBy isc:Paleoproterozoic ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Proterozoic> ;
 .
 
@@ -8670,7 +8052,6 @@ isc:Paleoproterozoic
   skos:prefLabel "原生代前期"@ja ;
   skos:prefLabel "古元古代"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Proterozoic ;
       skos:broaderTransitive isc:Precambrian ;
@@ -8679,7 +8060,7 @@ isc:Paleoproterozoic
       skos:narrower isc:Rhyacian ;
       skos:narrower isc:Siderian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseProterozoic ;
@@ -8695,8 +8076,7 @@ isc:Paleoproterozoic
       time:intervalStartedBy isc:Siderian ;
       time:intervalStarts isc:Proterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04  
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Paleoproterozoic> ;
 .
 
@@ -8734,13 +8114,12 @@ isc:Siderian
   skos:prefLabel "シデリアン紀"@ja ;
   skos:prefLabel "成铁纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleoproterozoic ;
       skos:broaderTransitive isc:Precambrian ;
       skos:broaderTransitive isc:Proterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseProterozoic ;
@@ -8751,8 +8130,7 @@ isc:Siderian
       time:intervalMetBy isc:Neoarchean ;
       time:intervalStarts isc:Paleoproterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Siderian> ;
 .
 
@@ -8790,13 +8168,12 @@ isc:Rhyacian
   skos:prefLabel "リヤシアン紀"@ja ;
   skos:prefLabel "层侵纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleoproterozoic ;
       skos:broaderTransitive isc:Proterozoic ;  
       skos:broaderTransitive isc:Precambrian ;    
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseRhyacian ;
@@ -8806,8 +8183,7 @@ isc:Rhyacian
       time:intervalMeets isc:Orosirian ;
       time:intervalMetBy isc:Siderian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Rhyacian> ;
 .
 
@@ -8845,13 +8221,12 @@ isc:Orosirian
   skos:prefLabel "オロシリアン紀"@ja ;
   skos:prefLabel "造山纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleoproterozoic ;
       skos:broaderTransitive isc:Precambrian ;
       skos:broaderTransitive isc:Proterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseOrosirian ;
@@ -8861,8 +8236,7 @@ isc:Orosirian
       time:intervalMeets isc:Statherian ;
       time:intervalMetBy isc:Rhyacian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Orosirian> ;
 .
 
@@ -8900,13 +8274,12 @@ isc:Statherian
   skos:prefLabel "スタテリアン紀"@ja ;
   skos:prefLabel "固结纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleoproterozoic ;
       skos:broaderTransitive isc:Precambrian ;
       skos:broaderTransitive isc:Proterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseStatherian ;
@@ -8917,8 +8290,7 @@ isc:Statherian
       time:intervalMeets isc:Mesoproterozoic ;
       time:intervalMetBy isc:Orosirian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Statherian> ;
 .
 
@@ -8956,7 +8328,6 @@ isc:Mesoproterozoic
   skos:prefLabel "中元古代"@zh ;
   skos:prefLabel "原生代中期"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Proterozoic ;
       skos:broaderTransitive isc:Precambrian ;
@@ -8964,7 +8335,7 @@ isc:Mesoproterozoic
       skos:narrower isc:Ectasian ;
       skos:narrower isc:Calymmian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMesoproterozoic ;
@@ -8979,8 +8350,7 @@ isc:Mesoproterozoic
       time:intervalMetBy isc:Statherian ;
       time:intervalStartedBy isc:Calymmian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Mesoproterozoic> ;
 .
 
@@ -9018,13 +8388,12 @@ isc:Calymmian
   skos:prefLabel "カリミアン紀"@ja ;
   skos:prefLabel "盖层纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Mesoproterozoic ;
       skos:broaderTransitive isc:Precambrian ;
       skos:broaderTransitive isc:Proterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMesoproterozoic ;
@@ -9035,8 +8404,7 @@ isc:Calymmian
       time:intervalMetBy isc:Statherian ;
       time:intervalStarts isc:Mesoproterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Calymmian> ;
 .
 
@@ -9074,13 +8442,12 @@ isc:Ectasian
   skos:prefLabel "エクタシアン紀"@ja ;
   skos:prefLabel "延展纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Mesoproterozoic ;
       skos:broaderTransitive isc:Precambrian ;
       skos:broaderTransitive isc:Proterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseEctasian ;
@@ -9090,8 +8457,7 @@ isc:Ectasian
       time:intervalMeets isc:Stenian ;
       time:intervalMetBy isc:Calymmian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Ectasian> ;
 .
 
@@ -9129,13 +8495,12 @@ isc:Stenian
   skos:prefLabel "ステニアン紀"@ja ;
   skos:prefLabel "狭带纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Mesoproterozoic ;
       skos:broaderTransitive isc:Precambrian ;
       skos:broaderTransitive isc:Proterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseStenian ;
@@ -9146,8 +8511,7 @@ isc:Stenian
       time:intervalMeets isc:Tonian ;
       time:intervalMetBy isc:Ectasian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Stenian> ;
 .
 
@@ -9185,7 +8549,6 @@ isc:Neoproterozoic
   skos:prefLabel "原生代後期"@ja ;
   skos:prefLabel "新元古代"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Proterozoic ;
       skos:broaderTransitive isc:Precambrian ;
@@ -9193,7 +8556,7 @@ isc:Neoproterozoic
       skos:narrower isc:Ediacaran ;
       skos:narrower isc:Tonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeoproterozoic ;
@@ -9211,7 +8574,7 @@ isc:Neoproterozoic
       time:intervalMetBy isc:Stenian ;
       time:intervalStartedBy isc:Tonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeoproterozoic ;
@@ -9229,7 +8592,7 @@ isc:Neoproterozoic
       time:intervalMetBy isc:Stenian ;
       time:intervalStartedBy isc:Tonian ;
       skos:inScheme ts:isc2006-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeoproterozoic ;
@@ -9247,7 +8610,7 @@ isc:Neoproterozoic
       time:intervalMetBy isc:Stenian ;
       time:intervalStartedBy isc:Tonian ;
       skos:inScheme ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeoproterozoic ;
@@ -9264,8 +8627,7 @@ isc:Neoproterozoic
       time:intervalMetBy isc:Stenian ;
       time:intervalStartedBy isc:Tonian ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Neoproterozoic> ;
 .
 
@@ -9303,13 +8665,12 @@ isc:Tonian
   skos:prefLabel "トニアン紀"@ja ;
   skos:prefLabel "拉伸纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Neoproterozoic ;
       skos:broaderTransitive isc:Precambrian ;
       skos:broaderTransitive isc:Proterozoic ;      
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeoproterozoic ;
@@ -9320,8 +8681,7 @@ isc:Tonian
       time:intervalMetBy isc:Stenian ;
       time:intervalStarts isc:Neoproterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Tonian> ;
 .
 
@@ -9359,13 +8719,12 @@ isc:Cryogenian
   skos:prefLabel "クリオジェニアン紀"@ja ;
   skos:prefLabel "成冰纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Neoproterozoic ;
       skos:broaderTransitive isc:Precambrian ;
       skos:broaderTransitive isc:Proterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCryogenian ;
@@ -9375,8 +8734,7 @@ isc:Cryogenian
       time:intervalMeets isc:Ediacaran ;
       time:intervalMetBy isc:Tonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Cryogenian> ;
 .
 
@@ -9415,13 +8773,12 @@ isc:Ediacaran
   skos:prefLabel "エディアカラ紀"@ja ;
   skos:prefLabel "埃迪卡拉纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Neoproterozoic ;
       skos:broaderTransitive isc:Precambrian ;
       skos:broaderTransitive isc:Proterozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseEdiacaran ;
@@ -9435,7 +8792,7 @@ isc:Ediacaran
       time:intervalMeets isc:Terreneuvian ;
       time:intervalMetBy isc:Cryogenian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseEdiacaran ;
@@ -9449,7 +8806,7 @@ isc:Ediacaran
       time:intervalMeets isc:Phanerozoic ;
       time:intervalMetBy isc:Cryogenian ;
       skos:inScheme ts:isc2006-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseEdiacaran ;
@@ -9463,7 +8820,7 @@ isc:Ediacaran
       time:intervalMeets isc:Phanerozoic ;
       time:intervalMetBy isc:Cryogenian ;
       skos:inScheme ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseEdiacaran ;
@@ -9476,8 +8833,7 @@ isc:Ediacaran
       time:intervalMeets isc:Phanerozoic ;
       time:intervalMetBy isc:Cryogenian ;
       skos:inScheme ts:isc2004-04
-      ] 
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Ediacaran> ;
 .
 
@@ -9516,7 +8872,6 @@ isc:Phanerozoic
   skos:prefLabel "顕生代"@ja ;
   skos:topConceptOf <http://resource.geosciml.org/classifier/ics/ischart/2017> ;
   dc:description  
-    (
       [   
       skos:narrower isc:Cenozoic ;
       skos:narrower isc:Mesozoic ;
@@ -9672,7 +9027,7 @@ isc:Phanerozoic
       skos:narrowerTransitive isc:Ypresian ;
       skos:narrowerTransitive isc:Zanclean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePhanerozoic ;
@@ -9685,8 +9040,7 @@ isc:Phanerozoic
       time:intervalMetBy isc:Proterozoic ;
       time:intervalStartedBy isc:Paleozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Phanerozoic> ;
 .
 
@@ -9726,7 +9080,6 @@ isc:Paleozoic
   skos:prefLabel "古生代"@ja ;
   skos:prefLabel "古生代"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Phanerozoic ;
       skos:narrower isc:Cambrian ;
@@ -9808,7 +9161,7 @@ isc:Paleozoic
       skos:narrowerTransitive isc:Wordian ;
       skos:narrowerTransitive isc:Wuchiapingian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePhanerozoic ;
@@ -9830,8 +9183,7 @@ isc:Paleozoic
       time:intervalStartedBy isc:Cambrian ;
       time:intervalStarts isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Paleozoic> ;
 .
 
@@ -9869,7 +9221,6 @@ isc:Cambrian
   skos:prefLabel "カンブリア紀"@ja ;
   skos:prefLabel "寒武纪"@zh ;
   dc:description  
-    (
       [
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broader isc:Paleozoic ;
@@ -9888,7 +9239,7 @@ isc:Cambrian
       skos:narrowerTransitive isc:Jiangshanian ;
       skos:narrowerTransitive isc:Paibian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       skos:broaderTransitive isc:Phanerozoic ;
@@ -9898,7 +9249,7 @@ isc:Cambrian
       skos:narrower isc:Terreneuvian ;
       skos:narrowerTransitive isc:Paibian ;
       skos:inScheme ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePhanerozoic ;
@@ -9917,7 +9268,7 @@ isc:Cambrian
       time:intervalStartedBy isc:Terreneuvian ;
       time:intervalStarts isc:Paleozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePhanerozoic ;
@@ -9935,8 +9286,7 @@ isc:Cambrian
       time:intervalStartedBy isc:Terreneuvian ;
       time:intervalStarts isc:Paleozoic ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Cambrian> ;
 .
 
@@ -9974,7 +9324,6 @@ isc:Terreneuvian
   skos:prefLabel "テレニュービアン世"@ja ;
   skos:prefLabel "纽芬兰世"@zh ;
   dc:description  
-    (
       [
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -9982,15 +9331,14 @@ isc:Terreneuvian
       skos:narrower isc:CambrianStage2 ;
       skos:narrower isc:Fortunian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broader isc:Cambrian ;
       skos:inScheme ts:isc2004-04
-      ]
-
+      ],
 
       [
       time:hasBeginning isc:BasePhanerozoic ;
@@ -10006,7 +9354,7 @@ isc:Terreneuvian
       time:intervalStartedBy isc:Fortunian ;
       time:intervalStarts isc:Cambrian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePhanerozoic ;
@@ -10019,8 +9367,7 @@ isc:Terreneuvian
       time:intervalMetBy isc:Proterozoic ;
       time:intervalStarts isc:Cambrian ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Terreneuvian> ;
 .
 
@@ -10058,14 +9405,13 @@ isc:Fortunian
   skos:prefLabel "フォルツニアン期"@ja ;
   skos:prefLabel "好运期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Terreneuvian ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePhanerozoic ;
@@ -10078,8 +9424,7 @@ isc:Fortunian
       time:intervalMetBy isc:Proterozoic ;
       time:intervalStarts isc:Terreneuvian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Fortunian> ;
 .
 
@@ -10116,14 +9461,13 @@ isc:CambrianStage2
   skos:prefLabel "第2期"@ja ;
   skos:prefLabel "第二期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Terreneuvian ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCambrianStage2 ;
@@ -10134,8 +9478,7 @@ isc:CambrianStage2
       time:intervalMeets isc:CambrianStage3 ;
       time:intervalMetBy isc:Fortunian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
 .
 
 
@@ -10171,7 +9514,6 @@ isc:CambrianSeries2
   skos:prefLabel "第2世"@ja ;
   skos:prefLabel "第二世"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -10179,14 +9521,14 @@ isc:CambrianSeries2
       skos:narrower isc:CambrianStage3 ;
       skos:narrower isc:CambrianStage4 ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       skos:broader isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCambrianSeries2 ;
@@ -10200,7 +9542,7 @@ isc:CambrianSeries2
       time:intervalMetBy isc:Terreneuvian ;
       time:intervalStartedBy isc:CambrianStage3 ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCambrianSeries2 ;
@@ -10211,8 +9553,7 @@ isc:CambrianSeries2
       time:intervalMeets isc:Paibian ;
       time:intervalMetBy isc:Terreneuvian ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
 .
 
 
@@ -10248,14 +9589,13 @@ isc:CambrianStage3
   skos:prefLabel "第3期"@ja ;
   skos:prefLabel "第三期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:CambrianSeries2 ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCambrianSeries2 ;
@@ -10266,8 +9606,7 @@ isc:CambrianStage3
       time:intervalMetBy isc:Terreneuvian ;
       time:intervalStarts isc:CambrianSeries2 ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
 .
 
 
@@ -10303,14 +9642,13 @@ isc:CambrianStage4
   skos:prefLabel "第4期"@ja ;
   skos:prefLabel "第四期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:CambrianSeries2 ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCambrianStage4 ;
@@ -10321,8 +9659,7 @@ isc:CambrianStage4
       time:intervalMeets isc:Wuliuan ;
       time:intervalMetBy isc:CambrianStage3 ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
 .
 
 
@@ -10358,7 +9695,6 @@ isc:Miaolingian
   #skos:prefLabel "第3世"@ja ;
   #skos:prefLabel "第三世"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -10367,7 +9703,7 @@ isc:Miaolingian
       skos:narrower isc:Drumian ;
       skos:narrower isc:Guzhangian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiaolingian ;
@@ -10382,8 +9718,7 @@ isc:Miaolingian
       time:intervalMetBy isc:CambrianStage4 ;
       time:intervalStartedBy isc:Wuliuan ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
 .
 
 
@@ -10419,14 +9754,13 @@ isc:Wuliuan
   #skos:prefLabel "第5期"@ja ;
   #skos:prefLabel "第五期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Miaolingian ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiaolingian ;
@@ -10437,8 +9771,7 @@ isc:Wuliuan
       time:intervalMetBy isc:CambrianStage4 ;
       time:intervalStarts isc:Miaolingian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
 .
 
 
@@ -10475,14 +9808,13 @@ isc:Drumian
   skos:prefLabel "ドルミアン期"@ja ;
   skos:prefLabel "鼓山期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Miaolingian ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseDrumian ;
@@ -10492,8 +9824,7 @@ isc:Drumian
       time:intervalMeets isc:Guzhangian ;
       time:intervalMetBy isc:Wuliuan ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Drumian> ;
 .
 
@@ -10531,14 +9862,13 @@ isc:Guzhangian
   skos:prefLabel "グザンギアン期"@ja ;
   skos:prefLabel "古丈期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Miaolingian ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseGuzhangian ;
@@ -10549,8 +9879,7 @@ isc:Guzhangian
       time:intervalMeets isc:Paibian ;
       time:intervalMetBy isc:Drumian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Guzhangian> ;
 .
 
@@ -10588,7 +9917,6 @@ isc:Furongian
   skos:prefLabel "フロンギアン世"@ja ;
   skos:prefLabel "芙蓉世"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -10597,7 +9925,7 @@ isc:Furongian
       skos:narrower isc:Jiangshanian ;
       skos:narrower isc:Paibian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       skos:broader isc:Cambrian ;
@@ -10605,7 +9933,7 @@ isc:Furongian
       skos:broaderTransitive isc:Phanerozoic ;
       skos:narrower isc:Paibian ;
       skos:inScheme ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseFurongian ;
@@ -10621,7 +9949,7 @@ isc:Furongian
       time:intervalMetBy isc:Guzhangian ;
       time:intervalStartedBy isc:Paibian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseFurongian ;
@@ -10634,8 +9962,7 @@ isc:Furongian
       time:intervalMetBy isc:CambrianSeries2 ;
       time:intervalStartedBy isc:Paibian ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Furongian> ;
 .
 
@@ -10673,14 +10000,13 @@ isc:Paibian
   skos:prefLabel "パイビアン期"@ja ;
   skos:prefLabel "排碧期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Furongian ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseFurongian ;
@@ -10691,7 +10017,7 @@ isc:Paibian
       time:intervalMetBy isc:Guzhangian ;
       time:intervalStarts isc:Furongian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseFurongian ;
@@ -10699,8 +10025,7 @@ isc:Paibian
       time:intervalMetBy isc:CambrianSeries2 ;
       time:intervalStarts isc:Furongian ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Paibian> ;
 .
 
@@ -10740,14 +10065,13 @@ isc:Jiangshanian
   skos:prefLabel "第9期"@ja ;
   skos:prefLabel "第九期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Furongian ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseJiangshanian ;
@@ -10757,8 +10081,7 @@ isc:Jiangshanian
       time:intervalMeets isc:CambrianStage10 ;
       time:intervalMetBy isc:Paibian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
 .
 
 
@@ -10794,14 +10117,13 @@ isc:CambrianStage10
   skos:prefLabel "第10期"@ja ;
   skos:prefLabel "第十期"@zh ;
   dc:description  
-    (
       [
       skos:broader isc:Furongian ;
       skos:broaderTransitive isc:Cambrian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCambrianStage10 ;
@@ -10813,8 +10135,7 @@ isc:CambrianStage10
       time:intervalMeets isc:Tremadocian ;
       time:intervalMetBy isc:Jiangshanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
 .
 
 
@@ -10851,7 +10172,6 @@ isc:Ordovician
   skos:prefLabel "オルドビス紀"@ja ;
   skos:prefLabel "奥陶纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -10866,7 +10186,7 @@ isc:Ordovician
       skos:narrowerTransitive isc:Sandbian ;
       skos:narrowerTransitive isc:Tremadocian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Paleozoic ;
@@ -10882,7 +10202,7 @@ isc:Ordovician
       skos:narrowerTransitive isc:OrdovicianStage6 ;
       skos:narrowerTransitive isc:Hirnantian ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Paleozoic ;
@@ -10894,7 +10214,7 @@ isc:Ordovician
       skos:narrowerTransitive isc:Darriwilian ;
       skos:narrowerTransitive isc:Hirnantian ;
       skos:inScheme ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseOrdovician ;
@@ -10911,7 +10231,7 @@ isc:Ordovician
       time:intervalMetBy isc:Furongian ;
       time:intervalStartedBy isc:LowerOrdovician ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseOrdovician ;
@@ -10928,7 +10248,7 @@ isc:Ordovician
       time:intervalMetBy isc:Furongian ;
       time:intervalStartedBy isc:LowerOrdovician ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseOrdovician ;
@@ -10944,8 +10264,7 @@ isc:Ordovician
       time:intervalMetBy isc:Furongian ;
       time:intervalStartedBy isc:LowerOrdovician ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Ordovician> ;
 .
 
@@ -10985,7 +10304,6 @@ isc:LowerOrdovician
   skos:prefLabel "前期オルドビス紀"@ja ;
   skos:prefLabel "早奥陶世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -10993,7 +10311,7 @@ isc:LowerOrdovician
       skos:narrower isc:Floian ;
       skos:narrower isc:Tremadocian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Ordovician ;
@@ -11002,7 +10320,7 @@ isc:LowerOrdovician
       skos:narrower isc:OrdovicianStage2 ;
       skos:narrower isc:Tremadocian ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Ordovician ;
@@ -11010,7 +10328,7 @@ isc:LowerOrdovician
       skos:broaderTransitive isc:Phanerozoic ;
       skos:narrower isc:Tremadocian ;
       skos:inScheme ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseOrdovician ;
@@ -11025,7 +10343,7 @@ isc:LowerOrdovician
       time:intervalStartedBy isc:Tremadocian ;
       time:intervalStarts isc:Ordovician ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseOrdovician ;
@@ -11040,7 +10358,7 @@ isc:LowerOrdovician
       time:intervalStartedBy isc:Tremadocian ;
       time:intervalStarts isc:Ordovician ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseOrdovician ;
@@ -11052,8 +10370,7 @@ isc:LowerOrdovician
       time:intervalStartedBy isc:Tremadocian ;
       time:intervalStarts isc:Ordovician ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/LowerOrdovician> ;
 .
 
@@ -11091,14 +10408,13 @@ isc:Tremadocian
   skos:prefLabel "トレマドキアン期"@ja ;
   skos:prefLabel "特马豆克期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerOrdovician ;
       skos:broaderTransitive isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseOrdovician ;
@@ -11110,7 +10426,7 @@ isc:Tremadocian
       time:intervalMetBy isc:Furongian ;
       time:intervalStarts isc:LowerOrdovician ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseOrdovician ;
@@ -11122,7 +10438,7 @@ isc:Tremadocian
       time:intervalMetBy isc:Furongian ;
       time:intervalStarts isc:LowerOrdovician ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseOrdovician ;
@@ -11132,8 +10448,7 @@ isc:Tremadocian
       time:intervalMetBy isc:Furongian ;
       time:intervalStarts isc:LowerOrdovician ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Tremadocian> ;
 .
 
@@ -11173,14 +10488,13 @@ isc:Floian
   skos:exactMatch isc:OrdovicianStage2 ;
   skos:historyNote "Previously known as 'OrdovicianStage2'" ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerOrdovician ;
       skos:broaderTransitive isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseFloian ;
@@ -11191,8 +10505,7 @@ isc:Floian
       time:intervalMeets isc:MiddleOrdovician ;
       time:intervalMetBy isc:Tremadocian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Floian> ;
 .
 
@@ -11239,7 +10552,6 @@ isc:MiddleOrdovician
   skos:prefLabel "中奥陶世"@zh ;
   skos:prefLabel "中期オルドビス紀"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -11247,7 +10559,7 @@ isc:MiddleOrdovician
       skos:narrower isc:Dapingian ;
       skos:narrower isc:Darriwilian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Ordovician ;
@@ -11256,7 +10568,7 @@ isc:MiddleOrdovician
       skos:narrower isc:OrdovicianStage3 ;
       skos:narrower isc:Darriwilian ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Ordovician ;
@@ -11264,7 +10576,7 @@ isc:MiddleOrdovician
       skos:broaderTransitive isc:Phanerozoic ;
       skos:narrower isc:Darriwilian ;
       skos:inScheme ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleOrdovician ;
@@ -11278,7 +10590,7 @@ isc:MiddleOrdovician
       time:intervalMetBy isc:LowerOrdovician ;
       time:intervalStartedBy isc:Dapingian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseMiddleOrdovician ;
@@ -11293,7 +10605,7 @@ isc:MiddleOrdovician
       time:intervalStartedBy isc:OrdovicianStage3 ;
       time:intervalStarts isc:Ordovician ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseMiddleOrdovician ;
@@ -11305,8 +10617,7 @@ isc:MiddleOrdovician
       time:intervalMetBy isc:LowerOrdovician ;
       time:intervalStarts isc:Ordovician ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/MiddleOrdovician> ;
 .
 
@@ -11347,14 +10658,13 @@ isc:Dapingian
   skos:exactMatch isc:OrdovicianStage3 ;
   skos:historyNote "Previously known as 'OrdovicianStage3'" ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleOrdovician ;
       skos:broaderTransitive isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleOrdovician ;
@@ -11365,7 +10675,7 @@ isc:Dapingian
       time:intervalMetBy isc:LowerOrdovician ;
       time:intervalStarts isc:MiddleOrdovician ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleOrdovician ;
@@ -11376,8 +10686,7 @@ isc:Dapingian
       time:intervalMetBy isc:LowerOrdovician ;
       time:intervalStarts isc:MiddleOrdovician ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Dapingian> ;
 .
 
@@ -11422,14 +10731,13 @@ isc:Darriwilian
   skos:prefLabel "ダーリウィリアン期"@ja ;
   skos:prefLabel "达瑞威尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleOrdovician ;
       skos:broaderTransitive isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseDarriwilian ;
@@ -11440,7 +10748,7 @@ isc:Darriwilian
       time:intervalMeets isc:UpperOrdovician ;
       time:intervalMetBy isc:Dapingian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseDarriwilian ;
@@ -11451,7 +10759,7 @@ isc:Darriwilian
       time:intervalMeets isc:UpperOrdovician ;
       time:intervalMetBy isc:OrdovicianStage2 ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseDarriwilian ;
@@ -11460,8 +10768,7 @@ isc:Darriwilian
       time:intervalIn isc:MiddleOrdovician ;
       time:intervalMeets isc:UpperOrdovician ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Darriwilian> ;
 .
 
@@ -11499,7 +10806,6 @@ isc:UpperOrdovician
   skos:prefLabel "後期オルドビス紀"@ja ;
   skos:prefLabel "晚奥陶世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -11508,7 +10814,7 @@ isc:UpperOrdovician
       skos:narrower isc:Katian ;
       skos:narrower isc:Sandbian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Ordovician ;
@@ -11518,7 +10824,7 @@ isc:UpperOrdovician
       skos:narrower isc:OrdovicianStage6 ;
       skos:narrower isc:Hirnantian ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Ordovician ;
@@ -11526,7 +10832,7 @@ isc:UpperOrdovician
       skos:broaderTransitive isc:Phanerozoic ;
       skos:narrower isc:Hirnantian ;
       skos:inScheme ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperOrdovician ;
@@ -11542,7 +10848,7 @@ isc:UpperOrdovician
       time:intervalMetBy isc:MiddleOrdovician ;
       time:intervalStartedBy isc:Sandbian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseUpperOrdovician ;
@@ -11558,7 +10864,7 @@ isc:UpperOrdovician
       time:intervalMetBy isc:MiddleOrdovician ;
       time:intervalStartedBy isc:OrdovicianStage5 ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseUpperOrdovician ;
@@ -11572,8 +10878,7 @@ isc:UpperOrdovician
       time:intervalMetBy isc:Darriwilian ;
       time:intervalMetBy isc:MiddleOrdovician ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/UpperOrdovician> ;
 .
 
@@ -11612,14 +10917,13 @@ isc:Sandbian
   skos:prefLabel "サンドビアン期"@ja ;
   skos:prefLabel "桑比期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperOrdovician ;
       skos:broaderTransitive isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperOrdovician ;
@@ -11630,7 +10934,7 @@ isc:Sandbian
       time:intervalMetBy isc:MiddleOrdovician ;
       time:intervalStarts isc:UpperOrdovician ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseUpperOrdovician ;
@@ -11641,8 +10945,7 @@ isc:Sandbian
       time:intervalMetBy isc:MiddleOrdovician ;
       time:intervalStarts isc:UpperOrdovician ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Sandbian> ;
 .
 
@@ -11692,14 +10995,13 @@ isc:Katian
   skos:prefLabel "カティアン期"@ja ;
   skos:prefLabel "凯迪期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperOrdovician ;
       skos:broaderTransitive isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseKatian ;
@@ -11709,7 +11011,7 @@ isc:Katian
       time:intervalMeets isc:Hirnantian ;
       time:intervalMetBy isc:Sandbian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseKatian ;
@@ -11719,8 +11021,7 @@ isc:Katian
       time:intervalMeets isc:Hirnantian ;
       time:intervalMetBy isc:OrdovicianStage5 ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Katian> ;
 .
 
@@ -11767,14 +11068,13 @@ isc:Hirnantian
   skos:prefLabel "ヒルナンティアン期"@ja ;
   skos:prefLabel "赫南特期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperOrdovician ;
       skos:broaderTransitive isc:Ordovician ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseHirnantian ;
@@ -11786,7 +11086,7 @@ isc:Hirnantian
       time:intervalMeets isc:Silurian ;
       time:intervalMetBy isc:Katian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseHirnantian ;
@@ -11798,7 +11098,7 @@ isc:Hirnantian
       time:intervalMeets isc:Silurian ;
       time:intervalMetBy isc:OrdovicianStage6 ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       time:hasBeginning isc:BaseHirnantian ;
@@ -11809,8 +11109,7 @@ isc:Hirnantian
       time:intervalMeets isc:Rhuddanian ;
       time:intervalMeets isc:Silurian ;
       skos:inScheme ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Hirnantian> ;
 .
 
@@ -11849,7 +11148,6 @@ isc:Silurian
   skos:prefLabel "シルル紀"@ja ;
   skos:prefLabel "志留纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -11865,7 +11163,7 @@ isc:Silurian
       skos:narrowerTransitive isc:Sheinwoodian ;
       skos:narrowerTransitive isc:Telychian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseSilurian ;
@@ -11883,8 +11181,7 @@ isc:Silurian
       time:intervalMetBy isc:UpperOrdovician ;
       time:intervalStartedBy isc:Llandovery ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Silurian> ;
 .
 
@@ -11922,7 +11219,6 @@ isc:Llandovery
   skos:prefLabel "ランドベリアン世"@ja ;
   skos:prefLabel "兰多维列世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Silurian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -11931,7 +11227,7 @@ isc:Llandovery
       skos:narrower isc:Rhuddanian ;
       skos:narrower isc:Telychian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseSilurian ;
@@ -11947,8 +11243,7 @@ isc:Llandovery
       time:intervalStartedBy isc:Rhuddanian ;
       time:intervalStarts isc:Silurian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Llandovery> ;
 .
 
@@ -11986,14 +11281,13 @@ isc:Rhuddanian
   skos:prefLabel "ルダニアン期"@ja ;
   skos:prefLabel "鲁丹期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Llandovery ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Silurian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseSilurian ;
@@ -12005,8 +11299,7 @@ isc:Rhuddanian
       time:intervalMetBy isc:UpperOrdovician ;
       time:intervalStarts isc:Llandovery ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Rhuddanian> ;
 .
 
@@ -12044,14 +11337,13 @@ isc:Aeronian
   skos:prefLabel "アエロニアン期"@ja ;
   skos:prefLabel "埃隆期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Llandovery ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Silurian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseAeronian ;
@@ -12061,8 +11353,7 @@ isc:Aeronian
       time:intervalMeets isc:Telychian ;
       time:intervalMetBy isc:Rhuddanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Aeronian> ;
 .
 
@@ -12100,14 +11391,13 @@ isc:Telychian
   skos:prefLabel "テリチアン期"@ja ;
   skos:prefLabel "特列奇期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Llandovery ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Silurian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseTelychian ;
@@ -12118,8 +11408,7 @@ isc:Telychian
       time:intervalMeets isc:Wenlock ;
       time:intervalMetBy isc:Aeronian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Telychian> ;
 .
 
@@ -12157,7 +11446,6 @@ isc:Wenlock
   skos:prefLabel "ウェンロッキアン世"@ja ;
   skos:prefLabel "温洛克世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Silurian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -12165,7 +11453,7 @@ isc:Wenlock
       skos:narrower isc:Homerian ;
       skos:narrower isc:Sheinwoodian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseWenlock ;
@@ -12179,8 +11467,7 @@ isc:Wenlock
       time:intervalMetBy isc:Telychian ;
       time:intervalStartedBy isc:Sheinwoodian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Wenlock> ;
 .
 
@@ -12218,14 +11505,13 @@ isc:Sheinwoodian
   skos:prefLabel "シェインウッディアン期"@ja ;
   skos:prefLabel "申伍德期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Wenlock ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Silurian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseWenlock ;
@@ -12236,8 +11522,7 @@ isc:Sheinwoodian
       time:intervalMetBy isc:Telychian ;
       time:intervalStarts isc:Wenlock ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Sheinwoodian> ;
 .
 
@@ -12275,14 +11560,13 @@ isc:Homerian
   skos:prefLabel "ホメリアン期"@ja ;
   skos:prefLabel "侯默期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Wenlock ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Silurian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseHomerian ;
@@ -12293,8 +11577,7 @@ isc:Homerian
       time:intervalMeets isc:Ludlow ;
       time:intervalMetBy isc:Sheinwoodian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Homerian> ;
 .
 
@@ -12332,7 +11615,6 @@ isc:Ludlow
   skos:prefLabel "ルーロビアン世"@ja ;
   skos:prefLabel "卢德洛世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Silurian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -12340,7 +11622,7 @@ isc:Ludlow
       skos:narrower isc:Gorstian ;
       skos:narrower isc:Ludfordian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseLudlow ;
@@ -12353,8 +11635,7 @@ isc:Ludlow
       time:intervalMetBy isc:Wenlock ;
       time:intervalStartedBy isc:Gorstian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Ludlow> ;
 .
 
@@ -12392,14 +11673,13 @@ isc:Gorstian
   skos:prefLabel "ゴースティアン期"@ja ;
   skos:prefLabel "格斯特期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Ludlow ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Silurian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseLudlow ;
@@ -12410,8 +11690,7 @@ isc:Gorstian
       time:intervalMetBy isc:Wenlock ;
       time:intervalStarts isc:Ludlow ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Gorstian> ;
 .
 
@@ -12449,14 +11728,13 @@ isc:Ludfordian
   skos:prefLabel "ルドフォーディアン期"@ja ;
   skos:prefLabel "卢德福德期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Ludlow ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Silurian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseLudfordian ;
@@ -12466,8 +11744,7 @@ isc:Ludfordian
       time:intervalMeets isc:Pridoli ;
       time:intervalMetBy isc:Gorstian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Ludfordian> ;
 .
 
@@ -12505,13 +11782,12 @@ isc:Pridoli
   skos:prefLabel "プリドリアン世"@ja ;
   skos:prefLabel "普里多利世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Silurian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePridoli ;
@@ -12524,8 +11800,7 @@ isc:Pridoli
       time:intervalMetBy isc:Ludfordian ;
       time:intervalMetBy isc:Ludlow ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Pridoli> ;
 .
 
@@ -12563,7 +11838,6 @@ isc:Devonian
   skos:prefLabel "デボン紀"@ja ;
   skos:prefLabel "泥盆纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -12578,7 +11852,7 @@ isc:Devonian
       skos:narrowerTransitive isc:Lochkovian ;
       skos:narrowerTransitive isc:Pragian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseDevonian ;
@@ -12595,8 +11869,7 @@ isc:Devonian
       time:intervalMetBy isc:Silurian ;
       time:intervalStartedBy isc:LowerDevonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Devonian> ;
 .
 
@@ -12636,7 +11909,6 @@ isc:LowerDevonian
   skos:prefLabel "前期デボン紀"@ja ;
   skos:prefLabel "早泥盆世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -12645,7 +11917,7 @@ isc:LowerDevonian
       skos:narrower isc:Lochkovian ;
       skos:narrower isc:Pragian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseDevonian ;
@@ -12660,8 +11932,7 @@ isc:LowerDevonian
       time:intervalStartedBy isc:Lochkovian ;
       time:intervalStarts isc:Devonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/LowerDevonian> ;
 .
 
@@ -12699,14 +11970,13 @@ isc:Lochkovian
   skos:prefLabel "ロッコビアン期"@ja ;
   skos:prefLabel "洛赫科夫期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerDevonian ;
       skos:broaderTransitive isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseDevonian ;
@@ -12717,8 +11987,7 @@ isc:Lochkovian
       time:intervalMetBy isc:Silurian ;
       time:intervalStarts isc:LowerDevonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Lochkovian> ;
 .
 
@@ -12756,14 +12025,13 @@ isc:Pragian
   skos:prefLabel "プラギアン期"@ja ;
   skos:prefLabel "布拉格期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerDevonian ;
       skos:broaderTransitive isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePragian ;
@@ -12773,8 +12041,7 @@ isc:Pragian
       time:intervalMeets isc:Emsian ;
       time:intervalMetBy isc:Lochkovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Pragian> ;
 .
 
@@ -12812,14 +12079,13 @@ isc:Emsian
   skos:prefLabel "エムシアン期"@ja ;
   skos:prefLabel "艾姆斯期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerDevonian ;
       skos:broaderTransitive isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseEmsian ;
@@ -12830,8 +12096,7 @@ isc:Emsian
       time:intervalMeets isc:MiddleDevonian ;
       time:intervalMetBy isc:Pragian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Emsian> ;
 .
 
@@ -12871,7 +12136,6 @@ isc:MiddleDevonian
   skos:prefLabel "中期デボン紀"@ja ;
   skos:prefLabel "中泥盆世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -12879,7 +12143,7 @@ isc:MiddleDevonian
       skos:narrower isc:Eifelian ;
       skos:narrower isc:Givetian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleDevonian ;
@@ -12893,8 +12157,7 @@ isc:MiddleDevonian
       time:intervalMetBy isc:LowerDevonian ;
       time:intervalStartedBy isc:Eifelian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/MiddleDevonian> ;
 .
 
@@ -12932,14 +12195,13 @@ isc:Eifelian
   skos:prefLabel "アイフェリアン期"@ja ;
   skos:prefLabel "艾菲尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleDevonian ;
       skos:broaderTransitive isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleDevonian ;
@@ -12950,8 +12212,7 @@ isc:Eifelian
       time:intervalMetBy isc:LowerDevonian ;
       time:intervalStarts isc:MiddleDevonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Eifelian> ;
 .
 
@@ -12989,14 +12250,13 @@ isc:Givetian
   skos:prefLabel "ジベーチアン期"@ja ;
   skos:prefLabel "吉维特期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleDevonian ;
       skos:broaderTransitive isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseGivetian ;
@@ -13007,8 +12267,7 @@ isc:Givetian
       time:intervalMeets isc:UpperDevonian ;
       time:intervalMetBy isc:Eifelian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Givetian> ;
 .
 
@@ -13048,7 +12307,6 @@ isc:UpperDevonian
   skos:prefLabel "後期デボン紀"@ja ;
   skos:prefLabel "晚泥盆世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -13056,7 +12314,7 @@ isc:UpperDevonian
       skos:narrower isc:Famennian ;
       skos:narrower isc:Frasnian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperDevonian ;
@@ -13072,8 +12330,7 @@ isc:UpperDevonian
       time:intervalMetBy isc:MiddleDevonian ;
       time:intervalStartedBy isc:Frasnian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/UpperDevonian> ;
 .
 
@@ -13111,14 +12368,13 @@ isc:Frasnian
   skos:prefLabel "フラスニアン期"@ja ;
   skos:prefLabel "弗拉斯期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperDevonian ;
       skos:broaderTransitive isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperDevonian ;
@@ -13129,8 +12385,7 @@ isc:Frasnian
       time:intervalMetBy isc:MiddleDevonian ;
       time:intervalStarts isc:UpperDevonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Frasnian> ;
 .
 
@@ -13168,14 +12423,13 @@ isc:Famennian
   skos:prefLabel "ファメニアン期"@ja ;
   skos:prefLabel "法门期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperDevonian ;
       skos:broaderTransitive isc:Devonian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseFamennian ;
@@ -13188,8 +12442,7 @@ isc:Famennian
       time:intervalMeets isc:Tournaisian ;
       time:intervalMetBy isc:Frasnian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Famennian> ;
 .
 
@@ -13227,7 +12480,6 @@ isc:Carboniferous
   skos:prefLabel "石炭紀"@ja ;
   skos:prefLabel "石炭纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -13247,7 +12499,7 @@ isc:Carboniferous
       skos:narrowerTransitive isc:UpperPennsylvanian ;
       skos:narrowerTransitive isc:Visean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCarboniferous ;
@@ -13263,8 +12515,7 @@ isc:Carboniferous
       time:intervalMetBy isc:UpperDevonian ;
       time:intervalStartedBy isc:Mississippian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Carboniferous> ;
 .
 
@@ -13302,7 +12553,6 @@ isc:Mississippian
   skos:prefLabel "ミシシッピアン紀"@ja ;
   skos:prefLabel "密西西比亚纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Carboniferous ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -13314,7 +12564,7 @@ isc:Mississippian
       skos:narrowerTransitive isc:Tournaisian ;
       skos:narrowerTransitive isc:Visean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCarboniferous ;
@@ -13331,8 +12581,7 @@ isc:Mississippian
       time:intervalStartedBy isc:LowerMississippian ;
       time:intervalStarts isc:Carboniferous ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Mississippian> ;
 .
 
@@ -13353,7 +12602,6 @@ isc:LowerMississippian
   skos:prefLabel "前期ミシシッピアン紀"@ja ;
   skos:prefLabel "早密西西比世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Mississippian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13361,7 +12609,7 @@ isc:LowerMississippian
       skos:broaderTransitive isc:Phanerozoic ;
       skos:narrower isc:Tournaisian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCarboniferous ;
@@ -13374,8 +12622,7 @@ isc:LowerMississippian
       time:intervalMetBy isc:UpperDevonian ;
       time:intervalStarts isc:Mississippian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/LowerMississippian> ;
 .
 
@@ -13414,7 +12661,6 @@ isc:Tournaisian
   skos:prefLabel "トルネージアン期"@ja ;
   skos:prefLabel "杜内期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerMississippian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13422,7 +12668,7 @@ isc:Tournaisian
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCarboniferous ;
@@ -13434,8 +12680,7 @@ isc:Tournaisian
       time:intervalMetBy isc:Famennian ;
       time:intervalMetBy isc:UpperDevonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Tournaisian> ;
 .
 
@@ -13456,7 +12701,6 @@ isc:MiddleMississippian
   skos:prefLabel "中密西西比世"@zh ;
   skos:prefLabel "中期ミシシッピアン紀"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Mississippian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13464,7 +12708,7 @@ isc:MiddleMississippian
       skos:broaderTransitive isc:Phanerozoic ;
       skos:narrower isc:Visean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleMississippian ;
@@ -13476,8 +12720,7 @@ isc:MiddleMississippian
       time:intervalMetBy isc:LowerMississippian ;
       time:intervalMetBy isc:Tournaisian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/MiddleMississippian> ;
 .
 
@@ -13516,7 +12759,6 @@ isc:Visean
   skos:prefLabel "ビゼアン期"@ja ;
   skos:prefLabel "韦宪期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleMississippian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13524,7 +12766,7 @@ isc:Visean
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleMississippian ;
@@ -13535,8 +12777,7 @@ isc:Visean
       time:intervalMetBy isc:LowerMississippian ;
       time:intervalMetBy isc:Tournaisian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Visean> ;
 .
 
@@ -13557,7 +12798,6 @@ isc:UpperMississippian
   skos:prefLabel "後期ミシシッピアン紀"@ja ;
   skos:prefLabel "晚密西西比世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Mississippian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13565,7 +12805,7 @@ isc:UpperMississippian
       skos:broaderTransitive isc:Phanerozoic ;
       skos:narrower isc:Serpukhovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperMississippian ;
@@ -13579,8 +12819,7 @@ isc:UpperMississippian
       time:intervalMetBy isc:Visean ;
       time:intervalStartedBy isc:Serpukhovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/UpperMississippian> ;
 .
 
@@ -13619,7 +12858,6 @@ isc:Serpukhovian
   skos:prefLabel "サプコビアン期"@ja ;
   skos:prefLabel "谢尔普霍夫期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperMississippian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13627,7 +12865,7 @@ isc:Serpukhovian
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperMississippian ;
@@ -13640,8 +12878,7 @@ isc:Serpukhovian
       time:intervalMetBy isc:Visean ;
       time:intervalStarts isc:UpperMississippian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Serpukhovian> ;
 .
 
@@ -13679,7 +12916,6 @@ isc:Pennsylvanian
   skos:prefLabel "ペンシルバニア紀"@ja ;
   skos:prefLabel "宾夕法尼亚亚纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Carboniferous ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -13692,7 +12928,7 @@ isc:Pennsylvanian
       skos:narrowerTransitive isc:Kasimovian ;
       skos:narrowerTransitive isc:Moscovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePennsylvanian ;
@@ -13708,8 +12944,7 @@ isc:Pennsylvanian
       time:intervalMetBy isc:Serpukhovian ;
       time:intervalStartedBy isc:LowerPennsylvanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Pennsylvanian> ;
 .
 
@@ -13730,7 +12965,6 @@ isc:LowerPennsylvanian
   skos:prefLabel "前期ペンシルバニア紀"@ja ;
   skos:prefLabel "早宾夕法尼亚世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Pennsylvanian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13738,7 +12972,7 @@ isc:LowerPennsylvanian
       skos:broaderTransitive isc:Phanerozoic ;
       skos:narrower isc:Bashkirian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePennsylvanian ;
@@ -13750,8 +12984,7 @@ isc:LowerPennsylvanian
       time:intervalMetBy isc:Serpukhovian ;
       time:intervalStarts isc:Pennsylvanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/LowerPennsylvanian> ;
 .
 
@@ -13790,7 +13023,6 @@ isc:Bashkirian
   skos:prefLabel "バシキリアン期"@ja ;
   skos:prefLabel "巴什基尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerPennsylvanian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13798,7 +13030,7 @@ isc:Bashkirian
       skos:broaderTransitive isc:Pennsylvanian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePennsylvanian ;
@@ -13809,8 +13041,7 @@ isc:Bashkirian
       time:intervalMetBy isc:Mississippian ;
       time:intervalMetBy isc:Serpukhovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Bashkirian> ;
 .
 
@@ -13831,7 +13062,6 @@ isc:MiddlePennsylvanian
   skos:prefLabel "中宾夕法尼亚世"@zh ;
   skos:prefLabel "中期ペンシルバニア紀"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Pennsylvanian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13839,7 +13069,7 @@ isc:MiddlePennsylvanian
       skos:broaderTransitive isc:Phanerozoic ;
       skos:narrower isc:Moscovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddlePennsylvanian ;
@@ -13851,8 +13081,7 @@ isc:MiddlePennsylvanian
       time:intervalMetBy isc:Bashkirian ;
       time:intervalMetBy isc:LowerPennsylvanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/MiddlePennsylvanian> ;
 .
 
@@ -13891,7 +13120,6 @@ isc:Moscovian
   skos:prefLabel "モスコビアン期"@ja ;
   skos:prefLabel "莫斯科期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddlePennsylvanian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13899,7 +13127,7 @@ isc:Moscovian
       skos:broaderTransitive isc:Pennsylvanian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddlePennsylvanian ;
@@ -13910,8 +13138,7 @@ isc:Moscovian
       time:intervalMetBy isc:Bashkirian ;
       time:intervalMetBy isc:LowerPennsylvanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Moscovian> ;
 .
 
@@ -13951,7 +13178,6 @@ isc:UpperPennsylvanian
   skos:prefLabel "後期ペンシルバニア紀"@ja ;
   skos:prefLabel "晚宾夕法尼亚世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Pennsylvanian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -13960,7 +13186,7 @@ isc:UpperPennsylvanian
       skos:narrower isc:Gzhelian ;
       skos:narrower isc:Kasimovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperPennsylvanian ;
@@ -13975,8 +13201,7 @@ isc:UpperPennsylvanian
       time:intervalMetBy isc:Moscovian ;
       time:intervalStartedBy isc:Kasimovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/UpperPennsylvanian> ;
 .
 
@@ -14014,7 +13239,6 @@ isc:Kasimovian
   skos:prefLabel "カシモビアン期"@ja ;
   skos:prefLabel "卡西莫夫期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperPennsylvanian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -14022,7 +13246,7 @@ isc:Kasimovian
       skos:broaderTransitive isc:Pennsylvanian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperPennsylvanian ;
@@ -14033,8 +13257,7 @@ isc:Kasimovian
       time:intervalMetBy isc:Moscovian ;
       time:intervalStarts isc:UpperPennsylvanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Kasimovian> ;
 .
 
@@ -14072,7 +13295,6 @@ isc:Gzhelian
   skos:prefLabel "グゼリアン期"@ja ;
   skos:prefLabel "格热尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperPennsylvanian ;
       skos:broaderTransitive isc:Carboniferous ;
@@ -14080,7 +13302,7 @@ isc:Gzhelian
       skos:broaderTransitive isc:Pennsylvanian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseGzhelian ;
@@ -14092,8 +13314,7 @@ isc:Gzhelian
       time:intervalMeets isc:Permian ;
       time:intervalMetBy isc:Kasimovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Gzhelian> ;
 .
 
@@ -14131,7 +13352,6 @@ isc:Permian
   skos:prefLabel "ペルム紀"@ja ;
   skos:prefLabel "二叠纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -14148,7 +13368,7 @@ isc:Permian
       skos:narrowerTransitive isc:Wordian ;
       skos:narrowerTransitive isc:Wuchiapingian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePermian ;
@@ -14168,8 +13388,7 @@ isc:Permian
       time:intervalMetBy isc:UpperPennsylvanian ;
       time:intervalStartedBy isc:Cisuralian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Permian> ;
 .
 
@@ -14207,7 +13426,6 @@ isc:Cisuralian
   skos:prefLabel "キスラリアン世"@ja ;
   skos:prefLabel "乌拉尔世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Permian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -14217,7 +13435,7 @@ isc:Cisuralian
       skos:narrower isc:Kungurian ;
       skos:narrower isc:Sakmarian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePermian ;
@@ -14236,8 +13454,7 @@ isc:Cisuralian
       time:intervalStartedBy isc:Asselian ;
       time:intervalStarts isc:Permian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Cisuralian> ;
 .
 
@@ -14275,14 +13492,13 @@ isc:Asselian
   skos:prefLabel "アセリアン期"@ja ;
   skos:prefLabel "阿瑟尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Cisuralian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Permian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePermian ;
@@ -14296,8 +13512,7 @@ isc:Asselian
       time:intervalMetBy isc:UpperPennsylvanian ;
       time:intervalStarts isc:Cisuralian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Asselian> ;
 .
@@ -14336,14 +13551,13 @@ isc:Sakmarian
   skos:prefLabel "サクマリアン期"@ja ;
   skos:prefLabel "萨克马尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Cisuralian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Permian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseSakmarian ;
@@ -14353,8 +13567,7 @@ isc:Sakmarian
       time:intervalMeets isc:Artinskian ;
       time:intervalMetBy isc:Asselian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Sakmarian> ;
 .
 
@@ -14392,14 +13605,13 @@ isc:Artinskian
   skos:prefLabel "アルティンスキアン期"@ja ;
   skos:prefLabel "亚丁斯克期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Cisuralian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Permian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseArtinskian ;
@@ -14409,8 +13621,7 @@ isc:Artinskian
       time:intervalMeets isc:Kungurian ;
       time:intervalMetBy isc:Sakmarian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Artinskian> ;
 .
 
@@ -14448,14 +13659,13 @@ isc:Kungurian
   skos:prefLabel "クングリアン期"@ja ;
   skos:prefLabel "孔古尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Cisuralian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Permian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseKungurian ;
@@ -14466,8 +13676,7 @@ isc:Kungurian
       time:intervalMeets isc:Roadian ;
       time:intervalMetBy isc:Artinskian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Kungurian> ;
 .
 
@@ -14505,7 +13714,6 @@ isc:Guadalupian
   skos:prefLabel "ガダリューピアン世"@ja ;
   skos:prefLabel "瓜德鲁普世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Permian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -14514,7 +13722,7 @@ isc:Guadalupian
       skos:narrower isc:Roadian ;
       skos:narrower isc:Wordian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseGuadalupian ;
@@ -14530,8 +13738,7 @@ isc:Guadalupian
       time:intervalMetBy isc:Kungurian ;
       time:intervalStartedBy isc:Roadian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Guadalupian> ;
 .
 
@@ -14569,14 +13776,13 @@ isc:Roadian
   skos:prefLabel "ローディアン期"@ja ;
   skos:prefLabel "罗德期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Guadalupian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Permian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseGuadalupian ;
@@ -14588,8 +13794,7 @@ isc:Roadian
       time:intervalMetBy isc:Kungurian ;
       time:intervalStarts isc:Guadalupian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Roadian> ;
 .
 
@@ -14627,14 +13832,13 @@ isc:Wordian
   skos:prefLabel "ワーディアン期"@ja ;
   skos:prefLabel "沃德期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Guadalupian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Permian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseWordian ;
@@ -14644,8 +13848,7 @@ isc:Wordian
       time:intervalMeets isc:Capitanian ;
       time:intervalMetBy isc:Roadian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Wordian> ;
 .
 
@@ -14683,14 +13886,13 @@ isc:Capitanian
   skos:prefLabel "カピタニアン期"@ja ;
   skos:prefLabel "卡匹敦期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Guadalupian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Permian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCapitanian ;
@@ -14701,8 +13903,7 @@ isc:Capitanian
       time:intervalMeets isc:Roadian ;
       time:intervalMetBy isc:Wordian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Capitanian> ;
 .
 
@@ -14740,7 +13941,6 @@ isc:Lopingian
   skos:prefLabel "ロピンギアン世"@ja ;
   skos:prefLabel "乐平世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Permian ;
       skos:broaderTransitive isc:Paleozoic ;
@@ -14748,7 +13948,7 @@ isc:Lopingian
       skos:narrower isc:Changhsingian ;
       skos:narrower isc:Wuchiapingian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseLopingian ;
@@ -14763,8 +13963,7 @@ isc:Lopingian
       time:intervalMetBy isc:Guadalupian ;
       time:intervalStartedBy isc:Wuchiapingian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Lopingian> ;
 .
 
@@ -14802,14 +14001,13 @@ isc:Wuchiapingian
   skos:prefLabel "ウキアピンギアン期"@ja ;
   skos:prefLabel "吴家坪期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Lopingian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Permian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseLopingian ;
@@ -14819,8 +14017,7 @@ isc:Wuchiapingian
       time:intervalMetBy isc:Guadalupian ;
       time:intervalStarts isc:Lopingian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Wuchiapingian> ;
 .
 
@@ -14858,14 +14055,13 @@ isc:Changhsingian
   skos:prefLabel "チャンシンギアン期"@ja ;
   skos:prefLabel "长兴期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Lopingian ;
       skos:broaderTransitive isc:Paleozoic ;
       skos:broaderTransitive isc:Permian ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseChanghsingian ;
@@ -14878,8 +14074,7 @@ isc:Changhsingian
       time:intervalMeets isc:Triassic ;
       time:intervalMetBy isc:Wuchiapingian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Changhsingian> ;
 .
 
@@ -14917,7 +14112,6 @@ isc:Mesozoic
   skos:prefLabel "中生代"@ja ;
   skos:prefLabel "中生代"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Phanerozoic ;
       skos:narrower isc:Cretaceous ;
@@ -14962,7 +14156,7 @@ isc:Mesozoic
       skos:narrowerTransitive isc:UpperTriassic ;
       skos:narrowerTransitive isc:Valanginian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMesozoic ;
@@ -14981,8 +14175,7 @@ isc:Mesozoic
       time:intervalMetBy isc:Permian ;
       time:intervalStartedBy isc:Triassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Mesozoic> ;
 .
 
@@ -15020,7 +14213,6 @@ isc:Triassic
   skos:prefLabel "三叠纪"@zh ;
   skos:prefLabel "三畳紀"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -15035,7 +14227,7 @@ isc:Triassic
       skos:narrowerTransitive isc:Olenekian ;
       skos:narrowerTransitive isc:Rhaetian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMesozoic ;
@@ -15053,8 +14245,7 @@ isc:Triassic
       time:intervalStartedBy isc:LowerTriassic ;
       time:intervalStarts isc:Mesozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Triassic> ;
 .
 
@@ -15094,7 +14285,6 @@ isc:LowerTriassic
   skos:prefLabel "前期三畳紀"@ja ;
   skos:prefLabel "早三叠世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Triassic ;
       skos:broaderTransitive isc:Mesozoic ;
@@ -15102,7 +14292,7 @@ isc:LowerTriassic
       skos:narrower isc:Induan ;
       skos:narrower isc:Olenekian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMesozoic ;
@@ -15118,8 +14308,7 @@ isc:LowerTriassic
       time:intervalStartedBy isc:Induan ;
       time:intervalStarts isc:Triassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/LowerTriassic> ;
 .
 
@@ -15157,14 +14346,13 @@ isc:Induan
   skos:prefLabel "インドゥアン期"@ja ;
   skos:prefLabel "印度期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerTriassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Triassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMesozoic ;
@@ -15177,8 +14365,7 @@ isc:Induan
       time:intervalMetBy isc:Permian ;
       time:intervalStarts isc:LowerTriassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Induan> ;
 .
 
@@ -15216,14 +14403,13 @@ isc:Olenekian
   skos:prefLabel "オレネキアン期"@ja ;
   skos:prefLabel "奥伦尼克期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerTriassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Triassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseOlenekian ;
@@ -15234,8 +14420,7 @@ isc:Olenekian
       time:intervalMeets isc:MiddleTriassic ;
       time:intervalMetBy isc:Induan ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Olenekian> ;
 .
 
@@ -15275,7 +14460,6 @@ isc:MiddleTriassic
   skos:prefLabel "中三叠世"@zh ;
   skos:prefLabel "中期三畳紀"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Triassic ;
       skos:broaderTransitive isc:Mesozoic ;
@@ -15283,7 +14467,7 @@ isc:MiddleTriassic
       skos:narrower isc:Anisian ;
       skos:narrower isc:Ladinian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleTriassic ;
@@ -15297,8 +14481,7 @@ isc:MiddleTriassic
       time:intervalMetBy isc:Olenekian ;
       time:intervalStartedBy isc:Anisian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/MiddleTriassic> ;
 .
 
@@ -15336,14 +14519,13 @@ isc:Anisian
   skos:prefLabel "アニシアン期"@ja ;
   skos:prefLabel "安尼期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleTriassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Triassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleTriassic ;
@@ -15354,8 +14536,7 @@ isc:Anisian
       time:intervalMetBy isc:Olenekian ;
       time:intervalStarts isc:MiddleTriassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Anisian> ;
 .
 
@@ -15393,14 +14574,13 @@ isc:Ladinian
   skos:prefLabel "ラディニアン期"@ja ;
   skos:prefLabel "拉迪尼亚期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleTriassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Triassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseLadinian ;
@@ -15411,8 +14591,7 @@ isc:Ladinian
       time:intervalMeets isc:UpperTriassic ;
       time:intervalMetBy isc:Anisian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Ladinian> ;
 .
 
@@ -15452,7 +14631,6 @@ isc:UpperTriassic
   skos:prefLabel "後期三畳紀"@ja ;
   skos:prefLabel "晚三叠世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Triassic ;
       skos:broaderTransitive isc:Mesozoic ;
@@ -15461,7 +14639,7 @@ isc:UpperTriassic
       skos:narrower isc:Norian ;
       skos:narrower isc:Rhaetian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperTriassic ;
@@ -15477,8 +14655,7 @@ isc:UpperTriassic
       time:intervalMetBy isc:MiddleTriassic ;
       time:intervalStartedBy isc:Carnian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/UpperTriassic> ;
 .
 
@@ -15516,14 +14693,13 @@ isc:Carnian
   skos:prefLabel "カーニアン期"@ja ;
   skos:prefLabel "卡尼期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperTriassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Triassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperTriassic ;
@@ -15534,8 +14710,7 @@ isc:Carnian
       time:intervalMetBy isc:MiddleTriassic ;
       time:intervalStarts isc:UpperTriassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Carnian> ;
 .
 
@@ -15573,14 +14748,13 @@ isc:Norian
   skos:prefLabel "ノーリアン期"@ja ;
   skos:prefLabel "诺利克期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperTriassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Triassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNorian ;
@@ -15590,8 +14764,7 @@ isc:Norian
       time:intervalMeets isc:Rhaetian ;
       time:intervalMetBy isc:Carnian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Norian> ;
 .
 
@@ -15629,14 +14802,13 @@ isc:Rhaetian
   skos:prefLabel "レーティアン期"@ja ;
   skos:prefLabel "瑞替期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperTriassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Triassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseRhaetian ;
@@ -15648,8 +14820,7 @@ isc:Rhaetian
       time:intervalMeets isc:LowerJurassic ;
       time:intervalMetBy isc:Norian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Rhaetian> ;
 .
 
@@ -15687,7 +14858,6 @@ isc:Jurassic
   skos:prefLabel "ジュラ紀"@ja ;
   skos:prefLabel "侏罗纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -15706,7 +14876,7 @@ isc:Jurassic
       skos:narrowerTransitive isc:Tithonian ;
       skos:narrowerTransitive isc:Toarcian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseJurassic ;
@@ -15723,8 +14893,7 @@ isc:Jurassic
       time:intervalMetBy isc:UpperTriassic ;
       time:intervalStartedBy isc:LowerJurassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Jurassic> ;
 .
 
@@ -15764,7 +14933,6 @@ isc:LowerJurassic
   skos:prefLabel "前期ジュラ紀"@ja ;
   skos:prefLabel "早侏罗世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
@@ -15774,7 +14942,7 @@ isc:LowerJurassic
       skos:narrower isc:Sinemurian ;
       skos:narrower isc:Toarcian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseJurassic ;
@@ -15791,8 +14959,7 @@ isc:LowerJurassic
       time:intervalStartedBy isc:Hettangian ;
       time:intervalStarts isc:Jurassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/LowerJurassic> ;
 .
 
@@ -15830,14 +14997,13 @@ isc:Hettangian
   skos:prefLabel "ヘッタンギアン期"@ja ;
   skos:prefLabel "赫唐期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseJurassic ;
@@ -15849,8 +15015,7 @@ isc:Hettangian
       time:intervalMetBy isc:UpperTriassic ;
       time:intervalStarts isc:LowerJurassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Hettangian> ;
 .
 
@@ -15888,14 +15053,13 @@ isc:Sinemurian
   skos:prefLabel "シネムール期"@ja ;
   skos:prefLabel "辛涅穆尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseSinemurian ;
@@ -15905,8 +15069,7 @@ isc:Sinemurian
       time:intervalMeets isc:Pliensbachian ;
       time:intervalMetBy isc:Hettangian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Sinemurian> ;
 .
 
@@ -15944,14 +15107,13 @@ isc:Pliensbachian
   skos:prefLabel "プリンスバッキアン期"@ja ;
   skos:prefLabel "普连斯巴奇期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePliensbachian ;
@@ -15961,8 +15123,7 @@ isc:Pliensbachian
       time:intervalMeets isc:Toarcian ;
       time:intervalMetBy isc:Sinemurian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Pliensbachian> ;
 .
 
@@ -16000,14 +15161,13 @@ isc:Toarcian
   skos:prefLabel "トアルシアン期"@ja ;
   skos:prefLabel "托阿尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseToarcian ;
@@ -16018,8 +15178,7 @@ isc:Toarcian
       time:intervalMeets isc:MiddleJurassic ;
       time:intervalMetBy isc:Pliensbachian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Toarcian> ;
 .
 
@@ -16059,7 +15218,6 @@ isc:MiddleJurassic
   skos:prefLabel "中侏罗世"@zh ;
   skos:prefLabel "中期ジュラ紀"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
@@ -16069,7 +15227,7 @@ isc:MiddleJurassic
       skos:narrower isc:Bathonian ;
       skos:narrower isc:Callovian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleJurassic ;
@@ -16085,8 +15243,7 @@ isc:MiddleJurassic
       time:intervalMetBy isc:Toarcian ;
       time:intervalStartedBy isc:Aalenian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/MiddleJurassic> ;
 .
 
@@ -16124,14 +15281,13 @@ isc:Aalenian
   skos:prefLabel "アーレニアン期"@ja ;
   skos:prefLabel "阿连期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddleJurassic ;
@@ -16142,8 +15298,7 @@ isc:Aalenian
       time:intervalMetBy isc:Toarcian ;
       time:intervalStarts isc:MiddleJurassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Aalenian> ;
 .
 
@@ -16181,14 +15336,13 @@ isc:Bajocian
   skos:prefLabel "バジョシアン期"@ja ;
   skos:prefLabel "巴柔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseBajocian ;
@@ -16198,8 +15352,7 @@ isc:Bajocian
       time:intervalMeets isc:Bathonian ;
       time:intervalMetBy isc:Aalenian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Bajocian> ;
 .
 
@@ -16237,14 +15390,13 @@ isc:Bathonian
   skos:prefLabel "バソニアン期"@ja ;
   skos:prefLabel "巴通期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseBathonian ;
@@ -16254,8 +15406,7 @@ isc:Bathonian
       time:intervalMeets isc:Callovian ;
       time:intervalMetBy isc:Bajocian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Bathonian> ;
 .
 
@@ -16293,14 +15444,13 @@ isc:Callovian
   skos:prefLabel "カロビアン期"@ja ;
   skos:prefLabel "卡洛夫期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:MiddleJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCallovian ;
@@ -16311,8 +15461,7 @@ isc:Callovian
       time:intervalMeets isc:UpperJurassic ;
       time:intervalMetBy isc:Bathonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Callovian> ;
 .
 
@@ -16352,7 +15501,6 @@ isc:UpperJurassic
   skos:prefLabel "後期ジュラ紀"@ja ;
   skos:prefLabel "晚侏罗世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
@@ -16361,7 +15509,7 @@ isc:UpperJurassic
       skos:narrower isc:Oxfordian ;
       skos:narrower isc:Tithonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperJurassic ;
@@ -16377,8 +15525,7 @@ isc:UpperJurassic
       time:intervalMetBy isc:MiddleJurassic ;
       time:intervalStartedBy isc:Oxfordian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/UpperJurassic> ;
 .
 
@@ -16416,14 +15563,13 @@ isc:Oxfordian
   skos:prefLabel "オックスフォーディアン期"@ja ;
   skos:prefLabel "牛津期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperJurassic ;
@@ -16434,8 +15580,7 @@ isc:Oxfordian
       time:intervalMetBy isc:MiddleJurassic ;
       time:intervalStarts isc:UpperJurassic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Oxfordian> ;
 .
 
@@ -16473,14 +15618,13 @@ isc:Kimmeridgian
   skos:prefLabel "キンメリッジアン期"@ja ;
   skos:prefLabel "启莫里支期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseKimmeridgian ;
@@ -16490,8 +15634,7 @@ isc:Kimmeridgian
       time:intervalMeets isc:Tithonian ;
       time:intervalMetBy isc:Oxfordian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Kimmeridgian> ;
 .
 
@@ -16529,14 +15672,13 @@ isc:Tithonian
   skos:prefLabel "チトニアン期"@ja ;
   skos:prefLabel "提通期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperJurassic ;
       skos:broaderTransitive isc:Jurassic ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseTithonian ;
@@ -16548,8 +15690,7 @@ isc:Tithonian
       time:intervalMeets isc:LowerCretaceous ;
       time:intervalMetBy isc:Kimmeridgian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Tithonian> ;
 .
 
@@ -16587,7 +15728,6 @@ isc:Cretaceous
   skos:prefLabel "白亜紀"@ja ;
   skos:prefLabel "白垩纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -16606,7 +15746,7 @@ isc:Cretaceous
       skos:narrowerTransitive isc:Turonian ;
       skos:narrowerTransitive isc:Valanginian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCretaceous ;
@@ -16623,8 +15763,7 @@ isc:Cretaceous
       time:intervalMetBy isc:UpperJurassic ;
       time:intervalStartedBy isc:LowerCretaceous ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Cretaceous> ;
 .
 
@@ -16664,7 +15803,6 @@ isc:LowerCretaceous
   skos:prefLabel "前期白亜紀"@ja ;
   skos:prefLabel "早白垩世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
@@ -16676,7 +15814,7 @@ isc:LowerCretaceous
       skos:narrower isc:Hauterivian ;
       skos:narrower isc:Valanginian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCretaceous ;
@@ -16695,8 +15833,7 @@ isc:LowerCretaceous
       time:intervalStartedBy isc:Berriasian ;
       time:intervalStarts isc:Cretaceous ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/LowerCretaceous> ;
 .
 
@@ -16734,14 +15871,13 @@ isc:Berriasian
   skos:prefLabel "ベリアシアン期"@ja ;
   skos:prefLabel "贝利亚斯期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCretaceous ;
@@ -16753,8 +15889,7 @@ isc:Berriasian
       time:intervalMetBy isc:UpperJurassic ;
       time:intervalStarts isc:LowerCretaceous ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Berriasian> ;
 .
 
@@ -16792,14 +15927,13 @@ isc:Valanginian
   skos:prefLabel "バランギニアン期"@ja ;
   skos:prefLabel "凡兰吟期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseValanginian ;
@@ -16809,8 +15943,7 @@ isc:Valanginian
       time:intervalMeets isc:Hauterivian ;
       time:intervalMetBy isc:Berriasian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Valanginian> ;
 .
 
@@ -16848,14 +15981,13 @@ isc:Hauterivian
   skos:prefLabel "オーテリビアン期"@ja ;
   skos:prefLabel "豪特里维期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseHauterivian ;
@@ -16865,8 +15997,7 @@ isc:Hauterivian
       time:intervalMeets isc:Barremian ;
       time:intervalMetBy isc:Valanginian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Hauterivian> ;
 .
 
@@ -16904,14 +16035,13 @@ isc:Barremian
   skos:prefLabel "バレミアン期"@ja ;
   skos:prefLabel "巴列姆期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseBarremian ;
@@ -16921,8 +16051,7 @@ isc:Barremian
       time:intervalMeets isc:Aptian ;
       time:intervalMetBy isc:Hauterivian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Barremian> ;
 .
 
@@ -16960,14 +16089,13 @@ isc:Aptian
   skos:prefLabel "アプチアン期"@ja ;
   skos:prefLabel "阿普弟期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseAptian ;
@@ -16977,8 +16105,7 @@ isc:Aptian
       time:intervalMeets isc:Albian ;
       time:intervalMetBy isc:Barremian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Aptian> ;
 .
 
@@ -17016,14 +16143,13 @@ isc:Albian
   skos:prefLabel "アルビアン期"@ja ;
   skos:prefLabel "阿尔布期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:LowerCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseAlbian ;
@@ -17034,8 +16160,7 @@ isc:Albian
       time:intervalMeets isc:UpperCretaceous ;
       time:intervalMetBy isc:Aptian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Albian> ;
 .
 
@@ -17075,7 +16200,6 @@ isc:UpperCretaceous
   skos:prefLabel "後期白亜紀"@ja ;
   skos:prefLabel "晚白垩世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
@@ -17087,7 +16211,7 @@ isc:UpperCretaceous
       skos:narrower isc:Santonian ;
       skos:narrower isc:Turonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperCretaceous ;
@@ -17107,8 +16231,7 @@ isc:UpperCretaceous
       time:intervalMetBy isc:LowerCretaceous ;
       time:intervalStartedBy isc:Cenomanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/UpperCretaceous> ;
 .
 
@@ -17146,14 +16269,13 @@ isc:Cenomanian
   skos:prefLabel "セノマニアン期"@ja ;
   skos:prefLabel "森诺曼期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperCretaceous ;
@@ -17164,8 +16286,7 @@ isc:Cenomanian
       time:intervalMetBy isc:LowerCretaceous ;
       time:intervalStarts isc:UpperCretaceous ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Cenomanian> ;
 .
 
@@ -17203,14 +16324,13 @@ isc:Turonian
   skos:prefLabel "チュロニアン期"@ja ;
   skos:prefLabel "土仑期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseTuronian ;
@@ -17220,8 +16340,7 @@ isc:Turonian
       time:intervalMeets isc:Coniacian ;
       time:intervalMetBy isc:Cenomanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Turonian> ;
 .
 
@@ -17259,14 +16378,13 @@ isc:Coniacian
   skos:prefLabel "コニアシアン期"@ja ;
   skos:prefLabel "科尼亚克期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseConiacian ;
@@ -17276,8 +16394,7 @@ isc:Coniacian
       time:intervalMeets isc:Santonian ;
       time:intervalMetBy isc:Turonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Coniacian> ;
 .
 
@@ -17315,14 +16432,13 @@ isc:Santonian
   skos:prefLabel "サントニアン期"@ja ;
   skos:prefLabel "桑托期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseSantonian ;
@@ -17332,8 +16448,7 @@ isc:Santonian
       time:intervalMeets isc:Campanian ;
       time:intervalMetBy isc:Coniacian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Santonian> ;
 .
 
@@ -17371,14 +16486,13 @@ isc:Campanian
   skos:prefLabel "カンパニアン期"@ja ;
   skos:prefLabel "坎佩尼期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCampanian ;
@@ -17388,8 +16502,7 @@ isc:Campanian
       time:intervalMeets isc:Maastrichtian ;
       time:intervalMetBy isc:Santonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Campanian> ;
 .
 
@@ -17427,14 +16540,13 @@ isc:Maastrichtian
   skos:prefLabel "マーストリヒシアン期"@ja ;
   skos:prefLabel "马斯特里赫特期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:UpperCretaceous ;
       skos:broaderTransitive isc:Cretaceous ;
       skos:broaderTransitive isc:Mesozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMaastrichtian ;
@@ -17447,8 +16559,7 @@ isc:Maastrichtian
       time:intervalMeets isc:Paleogene ;
       time:intervalMetBy isc:Campanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Maastrichtian> ;
 .
 
@@ -17488,7 +16599,6 @@ isc:Cenozoic
   skos:prefLabel "新生代"@ja ;
   skos:prefLabel "新生代"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Phanerozoic ;
       skos:narrower isc:Neogene ;
@@ -17523,7 +16633,7 @@ isc:Cenozoic
       skos:narrowerTransitive isc:Ypresian ;
       skos:narrowerTransitive isc:Zanclean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCenozoic ;
@@ -17538,8 +16648,7 @@ isc:Cenozoic
       time:intervalMetBy isc:UpperCretaceous ;
       time:intervalStartedBy isc:Paleogene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Cenozoic> ;
 .
 
@@ -17579,7 +16688,6 @@ isc:Paleogene
   skos:prefLabel "古第三紀"@ja ;
   skos:prefLabel "早第三纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -17596,7 +16704,7 @@ isc:Paleogene
       skos:narrowerTransitive isc:Thanetian ;
       skos:narrowerTransitive isc:Ypresian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCenozoic ;
@@ -17614,8 +16722,7 @@ isc:Paleogene
       time:intervalStartedBy isc:Paleocene ;
       time:intervalStarts isc:Cenozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Paleogene> ;
 .
 
@@ -17655,7 +16762,6 @@ isc:Paleocene
   skos:prefLabel "古新世"@zh ;
   skos:prefLabel "暁新世"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleogene ;
       skos:broaderTransitive isc:Cenozoic ;
@@ -17664,7 +16770,7 @@ isc:Paleocene
       skos:narrower isc:Selandian ;
       skos:narrower isc:Thanetian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCenozoic ;
@@ -17681,8 +16787,7 @@ isc:Paleocene
       time:intervalStartedBy isc:Danian ;
       time:intervalStarts isc:Paleogene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Paleocene> ;
 .
 
@@ -17720,14 +16825,13 @@ isc:Danian
   skos:prefLabel "ダニアン期"@ja ;
   skos:prefLabel "丹麦期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Paleogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCenozoic ;
@@ -17740,8 +16844,7 @@ isc:Danian
       time:intervalMetBy isc:UpperCretaceous ;
       time:intervalStarts isc:Paleocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Danian> ;
 .
 
@@ -17779,14 +16882,13 @@ isc:Selandian
   skos:prefLabel "セランディアン期"@ja ;
   skos:prefLabel "塞兰特期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Paleogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseSelandian ;
@@ -17796,8 +16898,7 @@ isc:Selandian
       time:intervalMeets isc:Thanetian ;
       time:intervalMetBy isc:Danian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Selandian> ;
 .
 
@@ -17835,14 +16936,13 @@ isc:Thanetian
   skos:prefLabel "サネティアン期"@ja ;
   skos:prefLabel "塔内提期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Paleogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseThanetian ;
@@ -17853,8 +16953,7 @@ isc:Thanetian
       time:intervalMeets isc:Ypresian ;
       time:intervalMetBy isc:Selandian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Thanetian> ;
 .
 
@@ -17892,7 +16991,6 @@ isc:Eocene
   skos:prefLabel "始新世"@ja ;
   skos:prefLabel "始新世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleogene ;
       skos:broaderTransitive isc:Cenozoic ;
@@ -17902,7 +17000,7 @@ isc:Eocene
       skos:narrower isc:Priabonian ;
       skos:narrower isc:Ypresian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseEocene ;
@@ -17918,8 +17016,7 @@ isc:Eocene
       time:intervalMetBy isc:Thanetian ;
       time:intervalStartedBy isc:Ypresian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Eocene> ;
 .
 
@@ -17957,14 +17054,13 @@ isc:Ypresian
   skos:prefLabel "イプレシアン期"@ja ;
   skos:prefLabel "伊普雷斯期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Eocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Paleogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseEocene ;
@@ -17975,8 +17071,7 @@ isc:Ypresian
       time:intervalMetBy isc:Thanetian ;
       time:intervalStarts isc:Eocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Ypresian> ;
 .
 
@@ -18014,14 +17109,13 @@ isc:Lutetian
   skos:prefLabel "ルテシアン期"@ja ;
   skos:prefLabel "卢台特期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Eocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Paleogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseLutetian ;
@@ -18031,8 +17125,7 @@ isc:Lutetian
       time:intervalMeets isc:Bartonian ;
       time:intervalMetBy isc:Ypresian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Lutetian> ;
 .
 
@@ -18070,14 +17163,13 @@ isc:Bartonian
   skos:prefLabel "バートニアン期"@ja ;
   skos:prefLabel "巴尔顿期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Eocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Paleogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseBartonian ;
@@ -18087,8 +17179,7 @@ isc:Bartonian
       time:intervalMeets isc:Priabonian ;
       time:intervalMetBy isc:Lutetian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Bartonian> ;
 .
 
@@ -18126,14 +17217,13 @@ isc:Priabonian
   skos:prefLabel "プリアボニアン期"@ja ;
   skos:prefLabel "普里阿邦期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Eocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Paleogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePriabonian ;
@@ -18144,8 +17234,7 @@ isc:Priabonian
       time:intervalMeets isc:Rupelian ;
       time:intervalMetBy isc:Bartonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Priabonian> ;
 .
 
@@ -18183,7 +17272,6 @@ isc:Oligocene
   skos:prefLabel "渐新世"@zh ;
   skos:prefLabel "漸新世"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Paleogene ;
       skos:broaderTransitive isc:Cenozoic ;
@@ -18191,7 +17279,7 @@ isc:Oligocene
       skos:narrower isc:Chattian ;
       skos:narrower isc:Rupelian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseOligocene ;
@@ -18206,8 +17294,7 @@ isc:Oligocene
       time:intervalMetBy isc:Priabonian ;
       time:intervalStartedBy isc:Rupelian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Oligocene> ;
 .
 
@@ -18245,14 +17332,13 @@ isc:Rupelian
   skos:prefLabel "ルペル期"@ja ;
   skos:prefLabel "鲁珀利期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Oligocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Paleogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseOligocene ;
@@ -18263,8 +17349,7 @@ isc:Rupelian
       time:intervalMetBy isc:Priabonian ;
       time:intervalStarts isc:Oligocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Rupelian> ;
 .
 
@@ -18302,14 +17387,13 @@ isc:Chattian
   skos:prefLabel "シャティアン期"@ja ;
   skos:prefLabel "恰特期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Oligocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Paleogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseChattian ;
@@ -18321,8 +17405,7 @@ isc:Chattian
       time:intervalMeets isc:Neogene ;
       time:intervalMetBy isc:Rupelian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Chattian> ;
 .
 
@@ -18360,7 +17443,6 @@ isc:Neogene
   skos:prefLabel "新第三紀"@ja ;
   skos:prefLabel "晚第三纪"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -18376,7 +17458,7 @@ isc:Neogene
       skos:narrowerTransitive isc:Piacenzian ;
       rdfs:comment "Chart positions for quaternary and gelasian for 2008 are still under discussion"@en ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Cenozoic ;
@@ -18393,7 +17475,7 @@ isc:Neogene
       skos:narrowerTransitive isc:Piacenzian ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Cenozoic ;
@@ -18415,7 +17497,7 @@ isc:Neogene
       skos:narrowerTransitive isc:MiddlePleistocene ;
       skos:narrowerTransitive isc:UpperPleistocene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeogene ;
@@ -18431,7 +17513,7 @@ isc:Neogene
       time:intervalMetBy isc:Paleogene ;
       time:intervalStartedBy isc:Miocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeogene ;
@@ -18444,8 +17526,7 @@ isc:Neogene
       time:intervalMetBy isc:Paleogene ;
       time:intervalStartedBy isc:Miocene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Neogene> ;
 .
 
@@ -18483,7 +17564,6 @@ isc:Miocene
   skos:prefLabel "中新世"@ja ;
   skos:prefLabel "中新世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Neogene ;
       skos:broaderTransitive isc:Cenozoic ;
@@ -18495,7 +17575,7 @@ isc:Miocene
       skos:narrower isc:Serravallian ;
       skos:narrower isc:Tortonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeogene ;
@@ -18514,8 +17594,7 @@ isc:Miocene
       time:intervalStartedBy isc:Aquitanian ;
       time:intervalStarts isc:Neogene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Miocene> ;
 .
 
@@ -18553,14 +17632,13 @@ isc:Aquitanian
   skos:prefLabel "アキタニアン期"@ja ;
   skos:prefLabel "阿启坦期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Miocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNeogene ;
@@ -18572,8 +17650,7 @@ isc:Aquitanian
       time:intervalMetBy isc:Paleogene ;
       time:intervalStarts isc:Miocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Aquitanian> ;
 .
 
@@ -18611,14 +17688,13 @@ isc:Burdigalian
   skos:prefLabel "バーディガリアン期"@ja ;
   skos:prefLabel "布迪加尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Miocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseBurdigalian ;
@@ -18628,8 +17704,7 @@ isc:Burdigalian
       time:intervalMeets isc:Langhian ;
       time:intervalMetBy isc:Aquitanian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Burdigalian> ;
 .
 
@@ -18667,14 +17742,13 @@ isc:Langhian
   skos:prefLabel "ランギアン期"@ja ;
   skos:prefLabel "兰海期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Miocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseLanghian ;
@@ -18684,8 +17758,7 @@ isc:Langhian
       time:intervalMeets isc:Serravallian ;
       time:intervalMetBy isc:Burdigalian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Langhian> ;
 .
 
@@ -18723,14 +17796,13 @@ isc:Serravallian
   skos:prefLabel "サーラバリアン期"@ja ;
   skos:prefLabel "塞拉瓦尔期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Miocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseSerravallian ;
@@ -18740,8 +17812,7 @@ isc:Serravallian
       time:intervalMeets isc:Tortonian ;
       time:intervalMetBy isc:Langhian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Serravallian> ;
 .
 
@@ -18779,14 +17850,13 @@ isc:Tortonian
   skos:prefLabel "トートニアン期"@ja ;
   skos:prefLabel "托尔顿期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Miocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseTortonian ;
@@ -18796,8 +17866,7 @@ isc:Tortonian
       time:intervalMeets isc:Messinian ;
       time:intervalMetBy isc:Serravallian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Tortonian> ;
 .
 
@@ -18835,14 +17904,13 @@ isc:Messinian
   skos:prefLabel "メッシニアン期"@ja ;
   skos:prefLabel "墨西拿期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Miocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMessinian ;
@@ -18853,8 +17921,7 @@ isc:Messinian
       time:intervalMeets isc:Zanclean ;
       time:intervalMetBy isc:Tortonian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Messinian> ;
 .
 
@@ -18892,7 +17959,6 @@ isc:Pliocene
   skos:prefLabel "上新世"@zh ;
   skos:prefLabel "鮮新世"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Neogene ;
       skos:broaderTransitive isc:Cenozoic ;
@@ -18900,7 +17966,7 @@ isc:Pliocene
       skos:narrower isc:Piacenzian ;
       skos:narrower isc:Zanclean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Neogene ;
@@ -18910,7 +17976,7 @@ isc:Pliocene
       skos:narrower isc:Zanclean ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Neogene ;
@@ -18920,7 +17986,7 @@ isc:Pliocene
       skos:narrower isc:Zanclean ;
       skos:narrower isc:Gelasian ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePliocene ;
@@ -18935,7 +18001,7 @@ isc:Pliocene
       time:intervalMetBy isc:Miocene ;
       time:intervalStartedBy isc:Zanclean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePliocene ;
@@ -18950,7 +18016,7 @@ isc:Pliocene
       time:intervalMetBy isc:Miocene ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePliocene ;
@@ -18964,8 +18030,7 @@ isc:Pliocene
       time:intervalMetBy isc:Miocene ;
       time:intervalStartedBy isc:Zanclean ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Pliocene> ;
 .
 
@@ -19003,14 +18068,13 @@ isc:Zanclean
   skos:prefLabel "ザンクレアン期"@ja ;
   skos:prefLabel "赞克勒期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Pliocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePliocene ;
@@ -19021,8 +18085,7 @@ isc:Zanclean
       time:intervalMetBy isc:Miocene ;
       time:intervalStarts isc:Pliocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Zanclean> ;
 .
 
@@ -19060,14 +18123,13 @@ isc:Piacenzian
   skos:prefLabel "皮亚琴期"@zh ;
   skos:prefLabel "ﾋﾟｱｾﾝｼﾞｱﾝ期"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Pliocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08, ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePiacenzian ;
@@ -19079,7 +18141,7 @@ isc:Piacenzian
       time:intervalMeets isc:Quaternary ;
       time:intervalMetBy isc:Zanclean ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePiacenzian ;
@@ -19092,7 +18154,7 @@ isc:Piacenzian
       time:intervalMetBy isc:Zanclean ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BasePiacenzian ;
@@ -19102,8 +18164,7 @@ isc:Piacenzian
       time:intervalMeets isc:Gelasian ;
       time:intervalMetBy isc:Zanclean ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Piacenzian> ;
 .
 
@@ -19140,14 +18201,13 @@ isc:Gelasian
   skos:prefLabel "ゲラシアン期"@ja ;
   skos:prefLabel "格拉斯期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Pleistocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Quaternary ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Pleistocene ;
@@ -19156,7 +18216,7 @@ isc:Gelasian
       skos:broaderTransitive isc:Quaternary ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Pleistocene ;
@@ -19164,7 +18224,7 @@ isc:Gelasian
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Pliocene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseQuaternary ;
@@ -19176,7 +18236,7 @@ isc:Gelasian
       time:intervalMetBy isc:Pliocene ;
       time:intervalStarts isc:Pleistocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseQuaternary ;
@@ -19189,7 +18249,7 @@ isc:Gelasian
       time:intervalStarts isc:Pleistocene ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseGelasian ;
@@ -19200,8 +18260,7 @@ isc:Gelasian
       time:intervalMeets isc:LowerPleistocene ;
       time:intervalMetBy isc:Piacenzian ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Gelasian> ;
 .
 
@@ -19241,8 +18300,6 @@ isc:Quaternary
   skos:prefLabel "第四紀"@ja ;
   skos:prefLabel "第四纪"@zh ;
   dc:description  
-    (
-
       [   
       skos:broader isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
@@ -19256,7 +18313,7 @@ isc:Quaternary
       skos:narrowerTransitive isc:Northgrippian ;
       skos:narrowerTransitive isc:Meghalayan ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07
-      ]
+      ],
 
       [   
       skos:broader isc:Cenozoic ;
@@ -19268,7 +18325,7 @@ isc:Quaternary
       skos:narrowerTransitive isc:MiddlePleistocene ;
       skos:narrowerTransitive isc:UpperPleistocene ;
       skos:inScheme ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Cenozoic ;
@@ -19281,7 +18338,7 @@ isc:Quaternary
       skos:narrowerTransitive isc:UpperPleistocene ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseQuaternary ;
@@ -19294,7 +18351,7 @@ isc:Quaternary
       time:intervalMetBy isc:Pliocene ;
       time:intervalStartedBy isc:Pleistocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseQuaternary ;
@@ -19308,8 +18365,7 @@ isc:Quaternary
       time:intervalStartedBy isc:Pleistocene ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Quaternary> ;
 .
 
@@ -19347,7 +18403,6 @@ isc:Pleistocene
   skos:prefLabel "更新世"@ja ;
   skos:prefLabel "更新世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Quaternary ;
       skos:broaderTransitive isc:Cenozoic ;
@@ -19357,7 +18412,7 @@ isc:Pleistocene
       skos:narrower isc:MiddlePleistocene ;
       skos:narrower isc:UpperPleistocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Quaternary ;
@@ -19369,7 +18424,7 @@ isc:Pleistocene
       skos:narrower isc:UpperPleistocene ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Neogene ;
@@ -19379,7 +18434,7 @@ isc:Pleistocene
       skos:narrower isc:MiddlePleistocene ;
       skos:narrower isc:UpperPleistocene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseQuaternary ;
@@ -19395,7 +18450,7 @@ isc:Pleistocene
       time:intervalStartedBy isc:Gelasian ;
       time:intervalStarts isc:Quaternary ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseQuaternary ;
@@ -19412,7 +18467,7 @@ isc:Pleistocene
       time:intervalStarts isc:Quaternary ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCalabrian ;
@@ -19425,8 +18480,7 @@ isc:Pleistocene
       time:intervalMetBy isc:Pliocene ;
       time:intervalStartedBy isc:LowerPleistocene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Pleistocene> ;
 .
 
@@ -19468,14 +18522,13 @@ isc:Calabrian
   skos:prefLabel "カラブリア期"@ja ;
   skos:prefLabel "卡拉布里亚期"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Pleistocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Quaternary ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Pleistocene ;
@@ -19484,7 +18537,7 @@ isc:Calabrian
       skos:broaderTransitive isc:Quaternary ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Pleistocene ;
@@ -19492,7 +18545,7 @@ isc:Calabrian
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCalabrian ;
@@ -19502,7 +18555,7 @@ isc:Calabrian
       time:intervalMeets isc:MiddlePleistocene ;
       time:intervalMetBy isc:Gelasian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCalabrian ;
@@ -19513,7 +18566,7 @@ isc:Calabrian
       time:intervalMetBy isc:Gelasian ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseCalabrian ;
@@ -19524,8 +18577,7 @@ isc:Calabrian
       time:intervalMetBy isc:Pliocene ;
       time:intervalStartedBy isc:LowerPleistocene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Calabrian> ;
 .
 
@@ -19594,14 +18646,13 @@ isc:MiddlePleistocene
   skos:prefLabel "Środkowy Plejstocen"@pl ;
   skos:prefLabel "Среден Плейѿтоцен"@bg ;
   dc:description  
-    (
       [   
       skos:broader isc:Pleistocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Quaternary ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Pleistocene ;
@@ -19610,7 +18661,7 @@ isc:MiddlePleistocene
       skos:broaderTransitive isc:Quaternary ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Pleistocene ;
@@ -19618,7 +18669,7 @@ isc:MiddlePleistocene
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddlePleistocene ;
@@ -19628,7 +18679,7 @@ isc:MiddlePleistocene
       time:intervalMeets isc:UpperPleistocene ;
       time:intervalMetBy isc:Calabrian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddlePleistocene ;
@@ -19639,7 +18690,7 @@ isc:MiddlePleistocene
       time:intervalMetBy isc:Calabrian ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMiddlePleistocene ;
@@ -19649,8 +18700,7 @@ isc:MiddlePleistocene
       time:intervalMeets isc:UpperPleistocene ;
       time:intervalMetBy isc:LowerPleistocene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Ionian> ;
 .
 
@@ -19700,14 +18750,13 @@ isc:UpperPleistocene
   skos:prefLabel "後期更新世"@ja ;
   skos:prefLabel "晚更新世"@zh ;
   dc:description  
-    (
       [   
       skos:broader isc:Pleistocene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Quaternary ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Pleistocene ;
@@ -19716,7 +18765,7 @@ isc:UpperPleistocene
       skos:broaderTransitive isc:Quaternary ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Pleistocene ;
@@ -19724,7 +18773,7 @@ isc:UpperPleistocene
       skos:broaderTransitive isc:Phanerozoic ;
       skos:broaderTransitive isc:Neogene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseUpperPleistocene ;
@@ -19734,8 +18783,7 @@ isc:UpperPleistocene
       time:intervalMeets isc:Holocene ;
       time:intervalMetBy isc:MiddlePleistocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/UpperPleistocene> ;
 .
 
@@ -19773,7 +18821,6 @@ isc:Holocene
   skos:prefLabel "全新世"@zh ;
   skos:prefLabel "完新世"@ja ;
   dc:description  
-    (
       [   
       skos:broader isc:Quaternary ;
       skos:broaderTransitive isc:Cenozoic ;
@@ -19782,14 +18829,14 @@ isc:Holocene
       skos:narrower isc:Northgrippian ;
       skos:narrower isc:Meghalayan ;      
       skos:inScheme ts:isc2018-08, ts:isc2018-07
-      ]
+      ],
 
       [   
       skos:broader isc:Quaternary ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [   
       skos:broader isc:Quaternary ;
@@ -19797,14 +18844,14 @@ isc:Holocene
       skos:broaderTransitive isc:Phanerozoic ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [   
       skos:broader isc:Neogene ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseHolocene ;
@@ -19816,7 +18863,7 @@ isc:Holocene
       time:intervalMetBy isc:UpperPleistocene ;
       time:intervalStartedBy isc:Greenlandian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseHolocene ;
@@ -19826,7 +18873,7 @@ isc:Holocene
       time:intervalMetBy isc:Pleistocene ;
       time:intervalMetBy isc:UpperPleistocene ;
       skos:inScheme ts:isc2017-02, ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10, ts:isc2014-02, ts:isc2013-01, ts:isc2012-08, ts:isc2010-09, ts:isc2009-08, ts:isc2008-08
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseHolocene ;
@@ -19837,7 +18884,7 @@ isc:Holocene
       time:intervalMetBy isc:UpperPleistocene ;
       rdfs:comment "Proposed by ICS"@en ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseHolocene ;
@@ -19847,8 +18894,7 @@ isc:Holocene
       time:intervalMetBy isc:Pleistocene ;
       time:intervalMetBy isc:UpperPleistocene ;
       skos:inScheme ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
-      ]
-    ) ;
+      ] ;
   foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Holocene> ;
 .
 
@@ -19863,14 +18909,13 @@ isc:Greenlandian
   skos:inScheme ts:isc2018-08, ts:isc2018-07 ;
   #skos:notation "a1.1.3.5.3.2"^^gts:EraCode ;
   dc:description  
-    (
       [   
       skos:broader isc:Holocene ;
       skos:broaderTransitive isc:Quaternary ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;    
       skos:inScheme ts:isc2018-08, ts:isc2018-07
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseHolocene ;
@@ -19880,8 +18925,7 @@ isc:Greenlandian
       time:intervalMetBy isc:Pleistocene ;
       time:intervalMetBy isc:UpperPleistocene ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07
-      ]
-    ) ;
+      ] ;
   #foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Tremadocian> ;
 .
 
@@ -19895,14 +18939,13 @@ isc:Northgrippian
   skos:inScheme ts:isc2018-08, ts:isc2018-07 ;
   #skos:notation "a1.1.3.5.3.2"^^gts:EraCode ;
   dc:description  
-    (
       [   
       skos:broader isc:Holocene ;
       skos:broaderTransitive isc:Quaternary ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;    
       skos:inScheme ts:isc2018-08, ts:isc2018-07
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseNorthgrippian ;
@@ -19912,8 +18955,7 @@ isc:Northgrippian
       time:intervalMeets isc:Meghalayan ;
       time:intervalMetBy isc:Greenlandian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07
-      ]
-    ) ;
+      ] ;
   #foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Tremadocian> ;
 .
 
@@ -19928,14 +18970,13 @@ isc:Meghalayan
   skos:inScheme ts:isc2018-08, ts:isc2018-07 ;
   #skos:notation "a1.1.3.5.3.2"^^gts:EraCode ;
   dc:description  
-    (
       [   
       skos:broader isc:Holocene ;
       skos:broaderTransitive isc:Quaternary ;
       skos:broaderTransitive isc:Cenozoic ;
       skos:broaderTransitive isc:Phanerozoic ;    
       skos:inScheme ts:isc2018-08, ts:isc2018-07
-      ]
+      ],
 
       [
       time:hasBeginning isc:BaseMeghalayan ;
@@ -19944,8 +18985,7 @@ isc:Meghalayan
       time:intervalFinishes isc:Holocene ;
       time:intervalMetBy isc:Northgrippian ;
       skos:inScheme ts:isc2018-08, ts:isc2018-07
-      ]
-    ) ;
+      ] ;
   #foaf:primaryTopicOf <http://sweetontology.net/stateTimeGeologic/Tremadocian> ;
 .
 
@@ -22724,4 +21764,3 @@ ts:isc2004-04
   skos:hasTopConcept isc:Precambrian ;
   skos:prefLabel "International Chronostratigraphic Chart (2004)"@en ;
 .
-


### PR DESCRIPTION
See example code below, the round bracket () will make the each square
bracket [] item as an item in a sorted list using the nested 'first -
rest' structure. If there are more than 3 '[]' items, the nested
structure of the sorted list needs a lot of work in SPARQL query. In
this update we removed all those kind of sorted list structure.

dc:description
  (
    [
    time:numericDuration "0.2"^^xsd:decimal ;
    skos:inScheme ts:isc2018-08, ts:isc2018-07, ts:isc2017-02,
ts:isc2016-10, ts:isc2016-04, ts:isc2015-01, ts:isc2014-10,
ts:isc2014-02, ts:isc2013-01, ts:isc2012-08
    ]

    [
    time:numericDuration "0.6"^^xsd:decimal ;
    skos:inScheme ts:isc2010-09, ts:isc2009-08, ts:isc2008-08,
ts:isc2006-04, ts:isc2005-12, ts:isc2004-04
    ]
  ) ;